### PR TITLE
feat(frontend): add /thankyou route and interactive Thank You page

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
-# Public base URL of your backend API
-# Used by the frontend to call backend endpoints
+# Base URL of your backend API (no trailing slash)
+# Example for local backend running on 3000
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,3 @@
+# Public base URL of your backend API
+# Used by the frontend to call backend endpoints
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-  "extends": ["next", "next/core-web-vitals"],
+  "extends": ["next/core-web-vitals"],
   "rules": {
-    "@next/next/no-img-element": "off"
+    "@next/next/no-html-link-for-pages": "off"
   }
 }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-  "extends": ["next/core-web-vitals"],
+  "extends": ["next", "next/core-web-vitals"],
   "rules": {
-    "@next/next/no-html-link-for-pages": "off"
+    "@next/next/no-img-element": "off"
   }
 }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+.next
+node_modules
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,25 +1,6 @@
-# dependencies
-/node_modules
-/.pnp
-.pnp.js
-
-# testing
-/coverage
-
-# next.js
-/.next/
-/out/
-
-# production
-/build
-
-# misc
-.DS_Store
-*.log
+node_modules
+.next
+out
 .env
 .env.local
-.env.*.local
-
-# typescript
-*.tsbuildinfo
-next-env.d.ts
+.DS_Store

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,7 +1,25 @@
-.next
-node_modules
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.log
 .env
 .env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*.local
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,4 @@
+.next
+node_modules
+build
+out

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,11 +14,11 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
 
 ```
 cd frontend
-pnpm install # or npm install / yarn
-pnpm dev
+npm install # or pnpm install / yarn install
+npm run dev
 ```
 
-- Open http://localhost:3000 (if you run Next on port 3000, change as needed)
+- Open http://localhost:3001 if Next selects 3001 (backend might already use 3000). Adjust ports as needed.
 
 ## Auth flows
 
@@ -31,8 +31,8 @@ Cookies are set as httpOnly, sameSite=lax, secure in production, path '/'.
 
 ## Scripts
 
-- `pnpm dev` - run dev server
-- `pnpm build` - build for production
-- `pnpm start` - start production server
-- `pnpm lint` - lint
-- `pnpm type-check` - TypeScript type checking
+- `npm run dev` - run dev server
+- `npm run build` - build for production
+- `npm run start` - start production server
+- `npm run lint` - lint
+- `npm run type-check` - TypeScript type checking

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,38 +1,36 @@
-# Frontend (Next.js)
+# Frontend (Next.js App)
 
-Next.js App Router frontend integrated with existing backend auth APIs (login/register/me).
+A modern Next.js 14 (App Router, TypeScript, Tailwind CSS) frontend that integrates with the existing backend APIs for authentication.
 
-## Quickstart
+## Prerequisites
+- Node.js 18+
+- pnpm, npm, or yarn
 
-- Copy `.env.example` to `.env.local` and set:
-
+## Setup
+1. Copy environment file
+```bash
+cp .env.example .env.local
 ```
-NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
-```
+2. Adjust `NEXT_PUBLIC_API_BASE_URL` to point to your backend (default: http://localhost:3000)
 
-- Install deps and run:
-
-```
-cd frontend
-npm install # or pnpm install / yarn install
+3. Install deps and run dev server
+```bash
+npm install
 npm run dev
+# opens on http://localhost:3001
 ```
 
-- Open the printed localhost URL (Next picks an available port, e.g., 3000 or 3001).
-
-## Auth flows
-
-- Login: POST /api/auth/login -> proxies to `${API_BASE_URL}/auth/login`, sets httpOnly `token` cookie
-- Register: POST /api/auth/register -> proxies to `${API_BASE_URL}/auth/register`, sets cookie
-- Me: Dashboard server component fetches `${API_BASE_URL}/users/me` with Authorization: Bearer token
-- Logout: POST /api/auth/logout -> clears cookie
-
-Cookies are set as httpOnly, sameSite=lax, secure in production, path '/'.
+## Auth Flow
+- Client pages call Next.js route handlers under `/api/auth/*`.
+- These handlers proxy to the backend and set/remove an httpOnly `token` cookie.
+- Protected routes (e.g., `/dashboard`) are guarded by middleware. Server component fetches `/users/me` using the cookie token.
 
 ## Scripts
+- `dev` - start dev server at 3001
+- `build` - build production
+- `start` - run production at 3001
+- `lint` - run ESLint
 
-- `npm run dev` - run dev server
-- `npm run build` - build for production
-- `npm run start` - start production server
-- `npm run lint` - lint
-- `npm run type-check` - TypeScript type checking
+## Notes
+- Cookie name: `token` (httpOnly, secure in production, sameSite=lax, path=/)
+- Tailwind is enabled via `globals.css` and `tailwind.config.ts`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,44 +1,38 @@
 # Frontend (Next.js)
 
-This is a minimal Next.js (App Router) + TypeScript + Tailwind CSS app that integrates with a backend providing:
-- POST /auth/register
-- POST /auth/login
-- GET /users/me
+Next.js App Router frontend integrated with existing backend auth APIs (login/register/me).
 
-It uses server Route Handlers to proxy auth and user requests to the backend, sets an httpOnly `token` cookie on successful login/register, and reads that cookie to call `/users/me`.
+## Quickstart
 
-## Getting Started
+- Copy `.env.example` to `.env.local` and set:
 
-Prerequisites:
-- Node.js 18+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+```
 
-Install dependencies:
+- Install deps and run:
 
-```bash
+```
 cd frontend
-npm install
+pnpm install # or npm install / yarn
+pnpm dev
 ```
 
-Configure environment variables (optional):
-- `NEXT_PUBLIC_API_BASE_URL` (default: `http://localhost:3000`)
+- Open http://localhost:3000 (if you run Next on port 3000, change as needed)
 
-Run the dev server:
+## Auth flows
 
-```bash
-npm run dev
-```
+- Login: POST /api/auth/login -> proxies to `${API_BASE_URL}/auth/login`, sets httpOnly `token` cookie
+- Register: POST /api/auth/register -> proxies to `${API_BASE_URL}/auth/register`, sets cookie
+- Me: Dashboard server component fetches `${API_BASE_URL}/users/me` with Authorization: Bearer token
+- Logout: POST /api/auth/logout -> clears cookie
 
-Open http://localhost:3000 (or the port shown) to view the app.
+Cookies are set as httpOnly, sameSite=lax, secure in production, path '/'.
 
-## App Structure
-- `src/app/(auth)/login` – Login page
-- `src/app/(auth)/register` – Register page
-- `src/app/dashboard` – Protected dashboard; loads profile via `/api/users/me`
-- `src/app/api/auth/*` – Proxy routes for login/register/logout; set/clear `token` cookie
-- `src/app/api/users/me` – Proxies `/users/me` including `Authorization: Bearer <token>`
-- `src/middleware.ts` – Redirects unauthenticated requests from `/dashboard` to `/login` and authenticated users from auth pages to `/dashboard`.
+## Scripts
 
-## Notes
-- The backend is expected to return `{ token: string }` or `{ accessToken: string }` on login/register.
-- The `token` is stored in an `httpOnly` cookie and is not accessible from client-side JavaScript.
-- Tailwind is set up with a few utility classes for simple styling.
+- `pnpm dev` - run dev server
+- `pnpm build` - build for production
+- `pnpm start` - start production server
+- `pnpm lint` - lint
+- `pnpm type-check` - TypeScript type checking

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,44 @@
+# Frontend (Next.js)
+
+This is a minimal Next.js (App Router) + TypeScript + Tailwind CSS app that integrates with a backend providing:
+- POST /auth/register
+- POST /auth/login
+- GET /users/me
+
+It uses server Route Handlers to proxy auth and user requests to the backend, sets an httpOnly `token` cookie on successful login/register, and reads that cookie to call `/users/me`.
+
+## Getting Started
+
+Prerequisites:
+- Node.js 18+
+
+Install dependencies:
+
+```bash
+cd frontend
+npm install
+```
+
+Configure environment variables (optional):
+- `NEXT_PUBLIC_API_BASE_URL` (default: `http://localhost:3000`)
+
+Run the dev server:
+
+```bash
+npm run dev
+```
+
+Open http://localhost:3000 (or the port shown) to view the app.
+
+## App Structure
+- `src/app/(auth)/login` – Login page
+- `src/app/(auth)/register` – Register page
+- `src/app/dashboard` – Protected dashboard; loads profile via `/api/users/me`
+- `src/app/api/auth/*` – Proxy routes for login/register/logout; set/clear `token` cookie
+- `src/app/api/users/me` – Proxies `/users/me` including `Authorization: Bearer <token>`
+- `src/middleware.ts` – Redirects unauthenticated requests from `/dashboard` to `/login` and authenticated users from auth pages to `/dashboard`.
+
+## Notes
+- The backend is expected to return `{ token: string }` or `{ accessToken: string }` on login/register.
+- The `token` is stored in an `httpOnly` cookie and is not accessible from client-side JavaScript.
+- Tailwind is set up with a few utility classes for simple styling.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,7 +18,7 @@ npm install # or pnpm install / yarn install
 npm run dev
 ```
 
-- Open http://localhost:3001 if Next selects 3001 (backend might already use 3000). Adjust ports as needed.
+- Open the printed localhost URL (Next picks an available port, e.g., 3000 or 3001).
 
 ## Auth flows
 

--- a/frontend/app/api/auth/login/route.ts
+++ b/frontend/app/api/auth/login/route.ts
@@ -1,0 +1,33 @@
+import { cookies } from 'next/headers'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000'
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+
+  const res = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  const data = await res.json().catch(() => ({}))
+
+  if (!res.ok) {
+    return new Response(JSON.stringify({ message: data?.message || 'Login failed' }), { status: res.status })
+  }
+
+  const token = data?.token
+  if (token) {
+    const secure = process.env.NODE_ENV === 'production'
+    cookies().set('token', token, {
+      httpOnly: true,
+      secure,
+      sameSite: 'lax',
+      path: '/',
+      // Optionally set maxAge based on backend provided exp if present
+    })
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200 })
+}

--- a/frontend/app/api/auth/logout/route.ts
+++ b/frontend/app/api/auth/logout/route.ts
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export async function POST() {
+  cookies().delete('token')
+  return new Response(JSON.stringify({ success: true }), { status: 200 })
+}

--- a/frontend/app/api/auth/register/route.ts
+++ b/frontend/app/api/auth/register/route.ts
@@ -1,0 +1,32 @@
+import { cookies } from 'next/headers'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000'
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}))
+
+  const res = await fetch(`${API_BASE_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  const data = await res.json().catch(() => ({}))
+
+  if (!res.ok) {
+    return new Response(JSON.stringify({ message: data?.message || 'Registration failed' }), { status: res.status })
+  }
+
+  const token = data?.token
+  if (token) {
+    const secure = process.env.NODE_ENV === 'production'
+    cookies().set('token', token, {
+      httpOnly: true,
+      secure,
+      sameSite: 'lax',
+      path: '/',
+    })
+  }
+
+  return new Response(JSON.stringify({ success: true }), { status: 200 })
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,39 @@
+import { getTokenFromCookies } from '@/lib/auth'
+import { API_BASE_URL } from '@/lib/api'
+
+export const dynamic = 'force-dynamic'
+
+export default async function DashboardPage() {
+  const token = getTokenFromCookies()
+  let me: any = null
+  let error: string | null = null
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store'
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data?.message || 'Failed to load user info')
+    }
+    me = await res.json()
+  } catch (e: any) {
+    error = e.message
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      {error ? (
+        <div className="toast toast-error" role="alert">{error}</div>
+      ) : (
+        <div className="rounded-lg border bg-white p-6 shadow-sm">
+          <p className="text-sm text-gray-600">You are logged in as</p>
+          <div className="mt-1">
+            <pre className="whitespace-pre-wrap break-words text-sm bg-gray-50 p-3 rounded-md border">{JSON.stringify(me, null, 2)}</pre>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -12,11 +12,11 @@ export default async function DashboardPage() {
       headers: { Authorization: `Bearer ${token}` },
       cache: 'no-store'
     })
+    const data = await res.json().catch(() => ({}))
     if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data?.message || 'Failed to load user info')
+      throw new Error((data as any)?.message || 'Failed to load user info')
     }
-    me = await res.json()
+    me = data
   } catch (e: any) {
     error = e.message
   }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: #fff;
+  --foreground: #111827;
+}
+
+html, body { height: 100%; }
+
+.container { max-width: 72rem; }
+
+/* Simple toast styles */
+.toast {
+  @apply rounded-md border px-4 py-3 text-sm shadow-sm;
+}
+.toast-error { @apply border-red-200 bg-red-50 text-red-800; }
+.toast-success { @apply border-green-200 bg-green-50 text-green-800; }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css'
+import { ReactNode } from 'react'
+import { Navbar } from '@/components/ui/navbar'
+
+export const metadata = {
+  title: 'Auth App',
+  description: 'Next.js frontend wired to backend auth',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="h-full bg-gray-50">
+      <body className="min-h-screen text-gray-900 antialiased">
+        <Navbar />
+        <main className="container mx-auto p-4">{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (!email || !password) {
+      setError('Please enter email and password')
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.message || 'Login failed')
+      router.push('/dashboard')
+      router.refresh()
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md">
+      <h1 className="text-2xl font-semibold">Login</h1>
+      <p className="text-gray-600 mt-1">Welcome back. Enter your credentials.</p>
+
+      {error && <div role="alert" className="toast toast-error mt-4">{error}</div>}
+
+      <form onSubmit={onSubmit} className="mt-6 space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium">Email</label>
+          <Input id="email" type="email" autoComplete="email" required value={email} onChange={e => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium">Password</label>
+          <Input id="password" type="password" autoComplete="current-password" required value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Signing in...' : 'Sign in'}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-sm text-gray-600">
+        Don&apos;t have an account?{' '}
+        <Link className="text-primary-600 hover:underline" href="/register">Create one</Link>
+      </p>
+    </div>
+  )
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export default function HomePage() {
+  return (
+    <div className="space-y-8">
+      <section className="text-center py-16">
+        <h1 className="text-4xl font-semibold tracking-tight">Welcome</h1>
+        <p className="mt-3 text-gray-600 max-w-lg mx-auto">
+          This is a modern Next.js frontend wired to your backend authentication APIs.
+        </p>
+        <div className="mt-6 flex items-center justify-center gap-3">
+          <Button asChild>
+            <Link href="/register">Get Started</Link>
+          </Button>
+          <Button variant="secondary" asChild>
+            <Link href="/login">I already have an account</Link>
+          </Button>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card title="Secure Auth" description="JWT stored in httpOnly cookies via server routes." />
+        <Card title="Protected Pages" description="/dashboard is gated by middleware and server fetching." />
+        <Card title="Tailwind UI" description="Accessible, responsive, and polished components." />
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    if (!name || !email || !password) {
+      setError('Please fill all fields')
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password })
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data?.message || 'Registration failed')
+      router.push('/dashboard')
+      router.refresh()
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md">
+      <h1 className="text-2xl font-semibold">Create an account</h1>
+      <p className="text-gray-600 mt-1">Start by filling the form below.</p>
+
+      {error && <div role="alert" className="toast toast-error mt-4">{error}</div>}
+
+      <form onSubmit={onSubmit} className="mt-6 space-y-4">
+        <div>
+          <label htmlFor="name" className="block text-sm font-medium">Name</label>
+          <Input id="name" type="text" required value={name} onChange={e => setName(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium">Email</label>
+          <Input id="email" type="email" autoComplete="email" required value={email} onChange={e => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium">Password</label>
+          <Input id="password" type="password" autoComplete="new-password" required value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Creating account...' : 'Create account'}
+        </Button>
+      </form>
+
+      <p className="mt-4 text-sm text-gray-600">
+        Already have an account?{' '}
+        <Link className="text-primary-600 hover:underline" href="/login">Sign in</Link>
+      </p>
+    </div>
+  )
+}

--- a/frontend/app/thankyou/confetti.module.css
+++ b/frontend/app/thankyou/confetti.module.css
@@ -1,0 +1,27 @@
+.confetti {
+  position: absolute;
+  inset: 0;
+}
+
+.piece {
+  position: absolute;
+  top: -10px;
+  width: 10px;
+  height: 16px;
+  border-radius: 2px;
+  opacity: 0.9;
+  animation-name: fall, spin;
+  animation-timing-function: linear, ease-in-out;
+  animation-iteration-count: 1, infinite;
+}
+
+@keyframes fall {
+  0% { transform: translate3d(0, -100%, 0) rotate(0deg); }
+  100% { transform: translate3d(0, 110vh, 0) rotate(360deg); }
+}
+
+@keyframes spin {
+  0% { transform: rotateX(0) rotateY(0); }
+  50% { transform: rotateX(180deg) rotateY(180deg); }
+  100% { transform: rotateX(360deg) rotateY(360deg); }
+}

--- a/frontend/app/thankyou/confetti.module.css
+++ b/frontend/app/thankyou/confetti.module.css
@@ -1,27 +1,34 @@
 .confetti {
   position: absolute;
   inset: 0;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .piece {
   position: absolute;
   top: -10px;
-  width: 10px;
-  height: 16px;
+  left: 50%;
+  width: 8px;
+  height: 14px;
+  background: hsl(var(--h) 80% 55%);
   border-radius: 2px;
   opacity: 0.9;
-  animation-name: fall, spin;
-  animation-timing-function: linear, ease-in-out;
-  animation-iteration-count: 1, infinite;
+  transform: translateX(calc(var(--x) * 1px)) rotate(var(--r));
+  animation: fall var(--d) linear infinite;
+  animation-delay: var(--delay);
 }
+
+/* Create colorful variety using nth-child variables */
+.piece:nth-child(6n + 1) { --h: 12;  --x: -200; --r: 8deg;  --d: 4.8s; --delay: -1.2s; }
+.piece:nth-child(6n + 2) { --h: 220; --x: -120; --r: -6deg; --d: 5.4s; --delay: -0.8s; }
+.piece:nth-child(6n + 3) { --h: 150; --x: -40;  --r: 3deg;  --d: 5.8s; --delay: -0.4s; }
+.piece:nth-child(6n + 4) { --h: 280; --x: 60;   --r: -12deg;--d: 5.1s; --delay: -1.4s; }
+.piece:nth-child(6n + 5) { --h: 45;  --x: 140;  --r: 4deg;  --d: 4.7s; --delay: -0.6s; }
+.piece:nth-child(6n + 6) { --h: 340; --x: 220;  --r: -9deg; --d: 5.6s; --delay: -1.0s; }
 
 @keyframes fall {
-  0% { transform: translate3d(0, -100%, 0) rotate(0deg); }
-  100% { transform: translate3d(0, 110vh, 0) rotate(360deg); }
-}
-
-@keyframes spin {
-  0% { transform: rotateX(0) rotateY(0); }
-  50% { transform: rotateX(180deg) rotateY(180deg); }
-  100% { transform: rotateX(360deg) rotateY(360deg); }
+  0%   { transform: translate(-50%, -10%) rotate(var(--r)); }
+  60%  { transform: translate(calc(-50% + var(--x) * 0.6px), 60vh) rotate(calc(var(--r) * 3)); }
+  100% { transform: translate(calc(-50% + var(--x) * 1px), 100vh) rotate(calc(var(--r) * 6)); opacity: 0.7; }
 }

--- a/frontend/app/thankyou/page.tsx
+++ b/frontend/app/thankyou/page.tsx
@@ -1,59 +1,36 @@
 import Link from 'next/link'
+import type { Metadata } from 'next'
 import { Button } from '@/components/ui/button'
 import styles from './confetti.module.css'
 
-export const metadata = { title: 'Thank You' }
+export const metadata: Metadata = {
+  title: 'Thank You',
+}
 
 export default function ThankYouPage() {
-  const pieces = Array.from({ length: 60 })
-  const colors = ['#f87171', '#fbbf24', '#34d399', '#60a5fa', '#a78bfa', '#f472b6']
-
   return (
-    <section className="relative overflow-hidden">
-      <div className={`pointer-events-none ${styles.confetti}`} aria-hidden>
-        {pieces.map((_, i) => {
-          const left = Math.random() * 100
-          const delay = Math.random() * 3
-          const duration = 3 + Math.random() * 2
-          const bg = colors[i % colors.length]
-          const transformOrigin = `${Math.random() * 50}% ${Math.random() * 50}%`
-          return (
-            <span
-              key={i}
-              className={styles.piece}
-              style={{
-                left: `${left}%`,
-                animationDelay: `${delay}s`,
-                animationDuration: `${duration}s`,
-                backgroundColor: bg,
-                transformOrigin,
-              }}
-            />
-          )
-        })}
+    <div className="relative">
+      {/* Lightweight CSS-only confetti */}
+      <div className={styles.confetti} aria-hidden="true">
+        {Array.from({ length: 24 }).map((_, i) => (
+          <span key={i} className={styles.piece} />
+        ))}
       </div>
 
-      <div className="relative z-10 container mx-auto px-4 py-24">
-        <div className="mx-auto max-w-2xl rounded-2xl border bg-white/90 p-8 text-center shadow-lg backdrop-blur">
-          <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 text-3xl">🎉</div>
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Thank You!</h1>
-          <p className="mt-3 text-base text-gray-600 sm:text-lg">
-            We appreciate you. Your action was successful. You can continue to your
-            dashboard or head back home.
-          </p>
-
-          <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-            <Button asChild>
-              <Link href="/dashboard">Go to Dashboard</Link>
-            </Button>
-            <Button asChild variant="secondary">
-              <Link href="/">Back to Home</Link>
-            </Button>
-          </div>
+      <section className="relative z-10 mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center gap-6 p-4 text-center">
+        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Thank you!</h1>
+        <p className="max-w-prose text-base text-gray-600 sm:text-lg">
+          We appreciate you. Your action was completed successfully.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button asChild>
+            <Link href="/dashboard">Go to dashboard</Link>
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href="/">Back to home</Link>
+          </Button>
         </div>
-      </div>
-
-      <div aria-hidden className="absolute inset-0 -z-10 bg-gradient-to-br from-primary-50 via-white to-primary-100" />
-    </section>
+      </section>
+    </div>
   )
 }

--- a/frontend/app/thankyou/page.tsx
+++ b/frontend/app/thankyou/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import type { Metadata } from 'next'
 import { Button } from '@/components/ui/button'
-import styles from './confetti.module.css'
 
 export const metadata: Metadata = {
   title: 'Thank You',
@@ -9,25 +8,24 @@ export const metadata: Metadata = {
 
 export default function ThankYouPage() {
   return (
-    <div className="relative">
-      {/* Lightweight CSS-only confetti */}
-      <div className={styles.confetti} aria-hidden="true">
-        {Array.from({ length: 24 }).map((_, i) => (
-          <span key={i} className={styles.piece} />
-        ))}
+    <div className="relative isolate overflow-hidden">
+      {/* Subtle animated gradient background using Tailwind only */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-10rem] h-[36rem] w-[36rem] -translate-x-1/2 rounded-full bg-gradient-to-tr from-violet-300 via-sky-200 to-rose-300 opacity-40 blur-3xl animate-pulse" />
+        <div className="absolute right-[-8rem] bottom-[-8rem] h-[28rem] w-[28rem] rounded-full bg-gradient-to-tr from-emerald-200 via-cyan-200 to-indigo-200 opacity-30 blur-3xl animate-pulse [animation-duration:4s]" />
       </div>
 
-      <section className="relative z-10 mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center gap-6 p-4 text-center">
+      <section className="mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center gap-6 p-6 text-center">
         <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">Thank you!</h1>
         <p className="max-w-prose text-base text-gray-600 sm:text-lg">
-          We appreciate you. Your action was completed successfully.
+          Your action was completed successfully.
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
           <Button asChild>
-            <Link href="/dashboard">Go to dashboard</Link>
+            <Link href="/dashboard">Go to Dashboard</Link>
           </Button>
           <Button asChild variant="secondary">
-            <Link href="/">Back to home</Link>
+            <Link href="/">Back to Home</Link>
           </Button>
         </div>
       </section>

--- a/frontend/app/thankyou/page.tsx
+++ b/frontend/app/thankyou/page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import styles from './confetti.module.css'
+
+export const metadata = { title: 'Thank You' }
+
+export default function ThankYouPage() {
+  const pieces = Array.from({ length: 60 })
+  const colors = ['#f87171', '#fbbf24', '#34d399', '#60a5fa', '#a78bfa', '#f472b6']
+
+  return (
+    <section className="relative overflow-hidden">
+      <div className={`pointer-events-none ${styles.confetti}`} aria-hidden>
+        {pieces.map((_, i) => {
+          const left = Math.random() * 100
+          const delay = Math.random() * 3
+          const duration = 3 + Math.random() * 2
+          const bg = colors[i % colors.length]
+          const transformOrigin = `${Math.random() * 50}% ${Math.random() * 50}%`
+          return (
+            <span
+              key={i}
+              className={styles.piece}
+              style={{
+                left: `${left}%`,
+                animationDelay: `${delay}s`,
+                animationDuration: `${duration}s`,
+                backgroundColor: bg,
+                transformOrigin,
+              }}
+            />
+          )
+        })}
+      </div>
+
+      <div className="relative z-10 container mx-auto px-4 py-24">
+        <div className="mx-auto max-w-2xl rounded-2xl border bg-white/90 p-8 text-center shadow-lg backdrop-blur">
+          <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-primary-100 text-3xl">🎉</div>
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Thank You!</h1>
+          <p className="mt-3 text-base text-gray-600 sm:text-lg">
+            We appreciate you. Your action was successful. You can continue to your
+            dashboard or head back home.
+          </p>
+
+          <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <Button asChild>
+              <Link href="/dashboard">Go to Dashboard</Link>
+            </Button>
+            <Button asChild variant="secondary">
+              <Link href="/">Back to Home</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div aria-hidden className="absolute inset-0 -z-10 bg-gradient-to-br from-primary-50 via-white to-primary-100" />
+    </section>
+  )
+}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -1,0 +1,31 @@
+import { ButtonHTMLAttributes, forwardRef, AnchorHTMLAttributes } from 'react'
+import Link from 'next/link'
+import { clsx } from 'clsx'
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'ghost'
+  asChild?: boolean
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', asChild, ...props }, ref) => {
+    const base = 'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed'
+    const styles = {
+      primary: 'bg-primary-600 text-white hover:bg-primary-700 focus:ring-primary-600',
+      secondary: 'bg-white text-gray-900 border border-gray-300 hover:bg-gray-50 focus:ring-gray-300',
+      ghost: 'bg-transparent text-gray-700 hover:bg-gray-100 focus:ring-gray-200'
+    }[variant]
+
+    if (asChild) {
+      const A = Link as unknown as React.FC<AnchorHTMLAttributes<HTMLAnchorElement>>
+      return (
+        <A className={clsx(base, styles, className)} {...(props as any)} />
+      )
+    }
+
+    return (
+      <button ref={ref} className={clsx(base, styles, className)} {...props} />
+    )
+  }
+)
+Button.displayName = 'Button'

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -1,0 +1,15 @@
+type CardProps = {
+  title: string
+  description?: string
+  children?: React.ReactNode
+}
+
+export function Card({ title, description, children }: CardProps) {
+  return (
+    <div className="rounded-lg border bg-white p-6 shadow-sm">
+      <h3 className="text-lg font-medium">{title}</h3>
+      {description && <p className="mt-1 text-sm text-gray-600">{description}</p>}
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  )
+}

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import { InputHTMLAttributes, forwardRef } from 'react'
+import { clsx } from 'clsx'
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={clsx(
+        'mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500',
+        className
+      )}
+      {...props}
+    />
+  )
+})
+Input.displayName = 'Input'

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -17,9 +17,8 @@ export async function Navbar() {
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Link href="/" className="font-semibold">Auth App</Link>
         <nav className="flex items-center gap-3">
-          {/* Subtle, non-intrusive link */}
-          <Link href="/thankyou" className="hidden text-sm text-gray-500 transition-colors hover:text-gray-700 sm:inline-block">Thank You</Link>
-
+          {/* Small, unobtrusive link to Thank You page */}
+          <Link href="/thankyou" className="text-xs text-gray-500 hover:text-gray-700">Thank you</Link>
           {token ? (
             <>
               <Link href="/dashboard" className="text-sm text-gray-700 hover:text-gray-900">Dashboard</Link>

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -17,6 +17,9 @@ export async function Navbar() {
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <Link href="/" className="font-semibold">Auth App</Link>
         <nav className="flex items-center gap-3">
+          {/* Subtle, non-intrusive link */}
+          <Link href="/thankyou" className="hidden text-sm text-gray-500 transition-colors hover:text-gray-700 sm:inline-block">Thank You</Link>
+
           {token ? (
             <>
               <Link href="/dashboard" className="text-sm text-gray-700 hover:text-gray-900">Dashboard</Link>

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -1,13 +1,15 @@
 import Link from 'next/link'
 import { cookies } from 'next/headers'
 import { Button } from './button'
+import { redirect } from 'next/navigation'
 
 export async function Navbar() {
   const token = cookies().get('token')?.value
 
   async function logout() {
     'use server'
-    await fetch('/api/auth/logout', { method: 'POST' })
+    cookies().delete('token')
+    redirect('/login')
   }
 
   return (

--- a/frontend/components/ui/navbar.tsx
+++ b/frontend/components/ui/navbar.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link'
+import { cookies } from 'next/headers'
+import { Button } from './button'
+
+export async function Navbar() {
+  const token = cookies().get('token')?.value
+
+  async function logout() {
+    'use server'
+    await fetch('/api/auth/logout', { method: 'POST' })
+  }
+
+  return (
+    <header className="sticky top-0 z-10 border-b bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+      <div className="container mx-auto flex h-14 items-center justify-between px-4">
+        <Link href="/" className="font-semibold">Auth App</Link>
+        <nav className="flex items-center gap-3">
+          {token ? (
+            <>
+              <Link href="/dashboard" className="text-sm text-gray-700 hover:text-gray-900">Dashboard</Link>
+              <form action={logout}>
+                <Button type="submit" variant="secondary">Logout</Button>
+              </form>
+            </>
+          ) : (
+            <>
+              <Button asChild variant="secondary"><Link href="/login">Login</Link></Button>
+              <Button asChild><Link href="/register">Sign up</Link></Button>
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,26 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000'
+
+export function withAuthHeaders(token?: string) {
+  const headers: HeadersInit = { 'Content-Type': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+export async function backendFetch<T = any>(path: string, options: RequestInit = {}, token?: string): Promise<T> {
+  const url = `${API_BASE_URL}${path}`
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      ...(options.headers || {}),
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: 'no-store',
+  })
+  if (!res.ok) {
+    let msg = 'Request failed'
+    try { const data = await res.json(); msg = data?.message || msg } catch {}
+    throw new Error(msg)
+  }
+  try { return await res.json() } catch { return undefined as any }
+}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,0 +1,6 @@
+import { cookies } from 'next/headers'
+
+export function getTokenFromCookies() {
+  const token = cookies().get('token')?.value
+  return token
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('token')?.value
+  const { pathname } = req.nextUrl
+
+  if (pathname.startsWith('/dashboard') && !token) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*'],
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -2,16 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export function middleware(req: NextRequest) {
   const token = req.cookies.get('token')?.value
-  const { pathname } = req.nextUrl
+  const isProtected = req.nextUrl.pathname.startsWith('/dashboard')
 
-  if (pathname.startsWith('/dashboard') && !token) {
-    const url = req.nextUrl.clone()
-    url.pathname = '/login'
-    return NextResponse.redirect(url)
+  if (isProtected && !token) {
+    const loginUrl = new URL('/login', req.url)
+    loginUrl.searchParams.set('from', req.nextUrl.pathname)
+    return NextResponse.redirect(loginUrl)
   }
+
   return NextResponse.next()
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*'],
+  matcher: ['/dashboard/:path*']
 }

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb'
+    }
+  }
+}
+
+module.exports = nextConfig

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+}
+
+export default nextConfig

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+  },
 }
 
 export default nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,31 +1,29 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
   "private": true,
+  "version": "0.1.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@hookform/resolvers": "^3.3.4",
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest",
-    "react-hook-form": "^7.51.4",
-    "zod": "^3.23.8"
+    "next": "14.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "^3.23.8",
+    "react-hook-form": "^7.51.3",
+    "@hookform/resolvers": "^3.9.0"
   },
   "devDependencies": {
-    "@types/node": "^20.14.11",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "autoprefixer": "^10.4.19",
+    "autoprefixer": "^10.4.18",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "@types/node": "^20.12.12",
     "eslint": "^8.57.0",
-    "eslint-config-next": "latest",
-    "postcss": "^8.4.39",
-    "tailwindcss": "^3.4.7",
-    "typescript": "^5.5.3"
+    "eslint-config-next": "14.2.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-hook-form": "^7.51.3",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.4",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.7",
+    "typescript": "^5.5.3"
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,29 +1,30 @@
 {
   "name": "frontend",
-  "private": true,
   "version": "0.1.0",
+  "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
-    "next": "14.2.4",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-hook-form": "^7.51.3",
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-hook-form": "^7.51.4",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/node": "^20.14.10",
+    "@types/node": "^20.14.11",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
-    "eslint-config-next": "14.2.4",
-    "postcss": "^8.4.38",
+    "eslint-config-next": "latest",
+    "postcss": "^8.4.39",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.5.3"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,27 +3,26 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
-    "start": "next start",
-    "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "start": "next start -p 3001",
+    "lint": "next lint"
   },
   "dependencies": {
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "zod": "^3.23.8",
-    "react-hook-form": "^7.51.3",
-    "@hookform/resolvers": "^3.9.0"
+    "clsx": "2.1.0"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.18",
-    "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.5",
-    "@types/node": "^20.12.12",
-    "eslint": "^8.57.0",
-    "eslint-config-next": "14.2.5"
+    "@types/node": "20.12.12",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
   }
 }

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/frontend/src/app/(auth)/head.tsx
+++ b/frontend/src/app/(auth)/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <title>Auth</title>
+    </>
+  )
+}

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,0 +1,5 @@
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="max-w-md mx-auto">{children}</div>
+  )
+}

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,5 +1,3 @@
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="max-w-md mx-auto">{children}</div>
-  )
+  return <div className="mx-auto max-w-2xl p-6">{children}</div>
 }

--- a/frontend/src/app/(auth)/login/head.tsx
+++ b/frontend/src/app/(auth)/login/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <title>Login</title>
+    </>
+  )
+}

--- a/frontend/src/app/(auth)/login/loading.tsx
+++ b/frontend/src/app/(auth)/login/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p className="p-6">Loading…</p>
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -7,8 +7,8 @@ import { useState } from 'react'
 import Link from 'next/link'
 
 const schema = z.object({
-  email: z.string().email(),
-  password: z.string().min(6),
+  email: z.string().email('Valid email is required'),
+  password: z.string().min(6, 'Password must be at least 6 characters'),
 })
 
 type FormData = z.infer<typeof schema>

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import Link from 'next/link'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function LoginPage() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onSubmit = async (data: FormData) => {
+    setError(null); setLoading(true)
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      window.location.href = '/dashboard'
+    } catch (e: any) {
+      setError(e.message || 'Login failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="card">
+      <h1 className="text-xl font-semibold mb-4">Login</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Email</label>
+          <input className="input" type="email" {...register('email')} />
+          {errors.email && <p className="text-red-600 text-sm mt-1">{errors.email.message}</p>}
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <input className="input" type="password" {...register('password')} />
+          {errors.password && <p className="text-red-600 text-sm mt-1">{errors.password.message}</p>}
+        </div>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button className="button" type="submit" disabled={loading}>{loading ? 'Signing in...' : 'Sign In'}</button>
+      </form>
+      <p className="mt-4 text-sm">No account? <Link className="link" href="/register">Register</Link></p>
+    </div>
+  )
+}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,58 +1,74 @@
-"use client"
+'use client'
 
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
+import FormInput from '@/components/FormInput'
 import { useState } from 'react'
-import Link from 'next/link'
+import { Button } from '@/components/Button'
+import { useRouter } from 'next/navigation'
 
 const schema = z.object({
-  email: z.string().email('Valid email is required'),
-  password: z.string().min(6, 'Password must be at least 6 characters'),
+  email: z.string().email(),
+  password: z.string().min(6),
 })
 
 type FormData = z.infer<typeof schema>
 
 export default function LoginPage() {
-  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) })
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
 
   const onSubmit = async (data: FormData) => {
-    setError(null); setLoading(true)
-    try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!res.ok) throw new Error(await res.text())
-      window.location.href = '/dashboard'
-    } catch (e: any) {
-      setError(e.message || 'Login failed')
-    } finally {
-      setLoading(false)
+    setServerError(null)
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    if (res.ok) {
+      router.replace('/dashboard')
+      router.refresh()
+    } else {
+      const body = await res.json().catch(() => ({}))
+      setServerError(body.message || 'Login failed')
     }
   }
 
   return (
-    <div className="card">
-      <h1 className="text-xl font-semibold mb-4">Login</h1>
+    <div className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl font-semibold mb-6">Login</h1>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-        <div>
-          <label className="block mb-1">Email</label>
-          <input className="input" type="email" {...register('email')} />
-          {errors.email && <p className="text-red-600 text-sm mt-1">{errors.email.message}</p>}
-        </div>
-        <div>
-          <label className="block mb-1">Password</label>
-          <input className="input" type="password" {...register('password')} />
-          {errors.password && <p className="text-red-600 text-sm mt-1">{errors.password.message}</p>}
-        </div>
-        {error && <p className="text-red-600 text-sm">{error}</p>}
-        <button className="button" type="submit" disabled={loading}>{loading ? 'Signing in...' : 'Sign In'}</button>
+        <FormInput
+          label="Email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          {...register('email')}
+          error={errors.email}
+        />
+        <FormInput
+          label="Password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          {...register('password')}
+          error={errors.password}
+        />
+        {serverError && (
+          <p className="text-sm text-red-600" role="alert">
+            {serverError}
+          </p>
+        )}
+        <Button type="submit" loading={isSubmitting} className="w-full">
+          Sign in
+        </Button>
       </form>
-      <p className="mt-4 text-sm">No account? <Link className="link" href="/register">Register</Link></p>
     </div>
   )
 }

--- a/frontend/src/app/(auth)/register/head.tsx
+++ b/frontend/src/app/(auth)/register/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <title>Register</title>
+    </>
+  )
+}

--- a/frontend/src/app/(auth)/register/loading.tsx
+++ b/frontend/src/app/(auth)/register/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p className="p-6">Loading…</p>
+}

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -7,9 +7,9 @@ import Link from 'next/link'
 import { useState } from 'react'
 
 const schema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  password: z.string().min(6),
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Valid email is required'),
+  password: z.string().min(6, 'Password must be at least 6 characters'),
 })
 
 type FormData = z.infer<typeof schema>

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import Link from 'next/link'
+import { useState } from 'react'
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function RegisterPage() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onSubmit = async (data: FormData) => {
+    setError(null); setLoading(true)
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      window.location.href = '/dashboard'
+    } catch (e: any) {
+      setError(e.message || 'Registration failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="card">
+      <h1 className="text-xl font-semibold mb-4">Register</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Name</label>
+          <input className="input" type="text" {...register('name')} />
+          {errors.name && <p className="text-red-600 text-sm mt-1">{errors.name.message}</p>}
+        </div>
+        <div>
+          <label className="block mb-1">Email</label>
+          <input className="input" type="email" {...register('email')} />
+          {errors.email && <p className="text-red-600 text-sm mt-1">{errors.email.message}</p>}
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <input className="input" type="password" {...register('password')} />
+          {errors.password && <p className="text-red-600 text-sm mt-1">{errors.password.message}</p>}
+        </div>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button className="button" type="submit" disabled={loading}>{loading ? 'Creating account...' : 'Create account'}</button>
+      </form>
+      <p className="mt-4 text-sm">Already have an account? <Link className="link" href="/login">Login</Link></p>
+    </div>
+  )
+}

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -1,64 +1,94 @@
-"use client"
+'use client'
 
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import Link from 'next/link'
+import FormInput from '@/components/FormInput'
+import { Button } from '@/components/Button'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-const schema = z.object({
-  name: z.string().min(1, 'Name is required'),
-  email: z.string().email('Valid email is required'),
-  password: z.string().min(6, 'Password must be at least 6 characters'),
-})
+const schema = z
+  .object({
+    name: z.string().min(2),
+    email: z.string().email(),
+    password: z.string().min(6),
+    confirmPassword: z.string().min(6),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  })
 
 type FormData = z.infer<typeof schema>
 
 export default function RegisterPage() {
-  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({ resolver: zodResolver(schema) })
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) })
 
   const onSubmit = async (data: FormData) => {
-    setError(null); setLoading(true)
-    try {
-      const res = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!res.ok) throw new Error(await res.text())
-      window.location.href = '/dashboard'
-    } catch (e: any) {
-      setError(e.message || 'Registration failed')
-    } finally {
-      setLoading(false)
+    setServerError(null)
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: data.name,
+        email: data.email,
+        password: data.password,
+      }),
+    })
+    if (res.ok) {
+      router.replace('/dashboard')
+      router.refresh()
+    } else {
+      const body = await res.json().catch(() => ({}))
+      setServerError(body.message || 'Registration failed')
     }
   }
 
   return (
-    <div className="card">
-      <h1 className="text-xl font-semibold mb-4">Register</h1>
+    <div className="mx-auto max-w-md p-6">
+      <h1 className="text-2xl font-semibold mb-6">Register</h1>
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-        <div>
-          <label className="block mb-1">Name</label>
-          <input className="input" type="text" {...register('name')} />
-          {errors.name && <p className="text-red-600 text-sm mt-1">{errors.name.message}</p>}
-        </div>
-        <div>
-          <label className="block mb-1">Email</label>
-          <input className="input" type="email" {...register('email')} />
-          {errors.email && <p className="text-red-600 text-sm mt-1">{errors.email.message}</p>}
-        </div>
-        <div>
-          <label className="block mb-1">Password</label>
-          <input className="input" type="password" {...register('password')} />
-          {errors.password && <p className="text-red-600 text-sm mt-1">{errors.password.message}</p>}
-        </div>
-        {error && <p className="text-red-600 text-sm">{error}</p>}
-        <button className="button" type="submit" disabled={loading}>{loading ? 'Creating account...' : 'Create account'}</button>
+        <FormInput label="Name" name="name" {...register('name')} error={errors.name} />
+        <FormInput
+          label="Email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          {...register('email')}
+          error={errors.email}
+        />
+        <FormInput
+          label="Password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          {...register('password')}
+          error={errors.password}
+        />
+        <FormInput
+          label="Confirm Password"
+          name="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          {...register('confirmPassword')}
+          error={errors.confirmPassword}
+        />
+        {serverError && (
+          <p className="text-sm text-red-600" role="alert">
+            {serverError}
+          </p>
+        )}
+        <Button type="submit" loading={isSubmitting} className="w-full">
+          Create account
+        </Button>
       </form>
-      <p className="mt-4 text-sm">Already have an account? <Link className="link" href="/login">Login</Link></p>
     </div>
   )
 }

--- a/frontend/src/app/api/auth/[...path]/route.ts
+++ b/frontend/src/app/api/auth/[...path]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE_URL } from '@/lib/api'
+
+export async function GET(req: NextRequest, { params }: { params: { path: string[] } }) {
+  const url = `${API_BASE_URL}/auth/${params.path.join('/')}`
+  const res = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    cache: 'no-store',
+  })
+  const data = await res.json().catch(() => ({}))
+  return NextResponse.json(data, { status: res.status })
+}
+
+export async function POST(req: NextRequest, { params }: { params: { path: string[] } }) {
+  const url = `${API_BASE_URL}/auth/${params.path.join('/')}`
+  const body = await req.json().catch(() => ({}))
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const data = await res.json().catch(() => ({}))
+  return NextResponse.json(data, { status: res.status })
+}

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { API_BASE_URL } from '@/lib/api'
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+
+    const res = await fetch(`${API_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    const data = await res.json().catch(() => ({}))
+
+    if (!res.ok) {
+      return NextResponse.json(data || { message: 'Login failed' }, { status: res.status || 400 })
+    }
+
+    const token = (data && (data.token || data.accessToken)) as string | undefined
+    if (!token) {
+      return NextResponse.json({ message: 'Token missing in response' }, { status: 500 })
+    }
+
+    const cookieStore = cookies()
+    cookieStore.set('token', token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      // 7 days
+      maxAge: 60 * 60 * 24 * 7,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    return NextResponse.json({ message: e?.message || 'Unexpected error' }, { status: 500 })
+  }
+}

--- a/frontend/src/app/api/auth/login/route.ts
+++ b/frontend/src/app/api/auth/login/route.ts
@@ -1,40 +1,32 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { API_BASE_URL } from '@/lib/api'
+import { API_BASE_URL } from '@/lib/env'
 
-export async function POST(req: Request) {
-  try {
-    const body = await req.json()
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+  const res = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
 
-    const res = await fetch(`${API_BASE_URL}/auth/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
+  const data = await res.json().catch(() => null)
 
-    const data = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    return NextResponse.json(data || { message: 'Login failed' }, { status: res.status })
+  }
 
-    if (!res.ok) {
-      return NextResponse.json(data || { message: 'Login failed' }, { status: res.status || 400 })
-    }
-
-    const token = (data && (data.token || data.accessToken)) as string | undefined
-    if (!token) {
-      return NextResponse.json({ message: 'Token missing in response' }, { status: 500 })
-    }
-
+  const token = data?.token || data?.accessToken || data?.access_token
+  if (token) {
     const cookieStore = cookies()
     cookieStore.set('token', token, {
       httpOnly: true,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
       path: '/',
-      // 7 days
-      maxAge: 60 * 60 * 24 * 7,
+      maxAge: 60 * 60 * 24 * 7, // 7 days
     })
-
-    return NextResponse.json({ success: true })
-  } catch (e: any) {
-    return NextResponse.json({ message: e?.message || 'Unexpected error' }, { status: 500 })
   }
+
+  return NextResponse.json(data)
 }

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+export async function POST() {
+  const cookieStore = cookies()
+  cookieStore.set('token', '', { httpOnly: true, path: '/', maxAge: 0 })
+  return NextResponse.redirect(new URL('/login', process.env.NEXT_PUBLIC_BASE_PATH || 'http://localhost:3001'))
+}

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 
-export async function POST() {
+export async function POST(req: Request) {
   const cookieStore = cookies()
   cookieStore.set('token', '', { httpOnly: true, path: '/', maxAge: 0 })
-  return NextResponse.redirect(new URL('/login', process.env.NEXT_PUBLIC_BASE_PATH || 'http://localhost:3001'))
+  return NextResponse.redirect(new URL('/login', req.url))
 }

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 
-export async function POST(req: Request) {
+export async function POST() {
   const cookieStore = cookies()
-  cookieStore.set('token', '', { httpOnly: true, path: '/', maxAge: 0 })
-  return NextResponse.redirect(new URL('/login', req.url))
+  cookieStore.set('token', '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 0,
+  })
+  return NextResponse.json({ success: true })
 }

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,39 +1,32 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { API_BASE_URL } from '@/lib/api'
+import { API_BASE_URL } from '@/lib/env'
 
-export async function POST(req: Request) {
-  try {
-    const body = await req.json()
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+  const res = await fetch(`${API_BASE_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
 
-    const res = await fetch(`${API_BASE_URL}/auth/register`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
+  const data = await res.json().catch(() => null)
 
-    const data = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    return NextResponse.json(data || { message: 'Registration failed' }, { status: res.status })
+  }
 
-    if (!res.ok) {
-      return NextResponse.json(data || { message: 'Registration failed' }, { status: res.status || 400 })
-    }
-
-    const token = (data && (data.token || data.accessToken)) as string | undefined
-    if (!token) {
-      return NextResponse.json({ message: 'Token missing in response' }, { status: 500 })
-    }
-
+  const token = data?.token || data?.accessToken || data?.access_token
+  if (token) {
     const cookieStore = cookies()
     cookieStore.set('token', token, {
       httpOnly: true,
       sameSite: 'lax',
       secure: process.env.NODE_ENV === 'production',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7,
+      maxAge: 60 * 60 * 24 * 7, // 7 days
     })
-
-    return NextResponse.json({ success: true })
-  } catch (e: any) {
-    return NextResponse.json({ message: e?.message || 'Unexpected error' }, { status: 500 })
   }
+
+  return NextResponse.json(data)
 }

--- a/frontend/src/app/api/auth/register/route.ts
+++ b/frontend/src/app/api/auth/register/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { API_BASE_URL } from '@/lib/api'
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json()
+
+    const res = await fetch(`${API_BASE_URL}/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    const data = await res.json().catch(() => ({}))
+
+    if (!res.ok) {
+      return NextResponse.json(data || { message: 'Registration failed' }, { status: res.status || 400 })
+    }
+
+    const token = (data && (data.token || data.accessToken)) as string | undefined
+    if (!token) {
+      return NextResponse.json({ message: 'Token missing in response' }, { status: 500 })
+    }
+
+    const cookieStore = cookies()
+    cookieStore.set('token', token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 7,
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (e: any) {
+    return NextResponse.json({ message: e?.message || 'Unexpected error' }, { status: 500 })
+  }
+}

--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ ok: true })
+}

--- a/frontend/src/app/api/route.ts
+++ b/frontend/src/app/api/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ name: 'Next.js Frontend' })
+}

--- a/frontend/src/app/api/users/[...path]/route.ts
+++ b/frontend/src/app/api/users/[...path]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { API_BASE_URL } from '@/lib/api'
+import { cookies } from 'next/headers'
+
+export async function GET(req: NextRequest, { params }: { params: { path: string[] } }) {
+  const url = `${API_BASE_URL}/users/${params.path.join('/')}`
+  const token = cookies().get('token')?.value
+  const res = await fetch(url, {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(token ? { Cookie: `token=${token}` } : {}),
+    },
+    cache: 'no-store',
+  })
+  const data = await res.json().catch(() => ({}))
+  return NextResponse.json(data, { status: res.status })
+}

--- a/frontend/src/app/api/users/me/route.ts
+++ b/frontend/src/app/api/users/me/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { API_BASE_URL } from '@/lib/api'
+
+export async function GET() {
+  try {
+    const cookieStore = await cookies()
+    const token = cookieStore.get('token')?.value
+
+    const res = await fetch(`${API_BASE_URL}/users/me`, {
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(token ? { Cookie: `token=${token}` } : {}),
+      },
+      cache: 'no-store',
+    })
+
+    const data = await res.json().catch(() => ({}))
+
+    return NextResponse.json(data, { status: res.status })
+  } catch (e: any) {
+    return NextResponse.json({ message: e?.message || 'Unexpected error' }, { status: 500 })
+  }
+}

--- a/frontend/src/app/api/users/me/route.ts
+++ b/frontend/src/app/api/users/me/route.ts
@@ -4,7 +4,7 @@ import { API_BASE_URL } from '@/lib/api'
 
 export async function GET() {
   try {
-    const cookieStore = await cookies()
+    const cookieStore = cookies()
     const token = cookieStore.get('token')?.value
 
     const res = await fetch(`${API_BASE_URL}/users/me`, {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,5 +1,19 @@
+import { cookies, headers } from 'next/headers'
+
 export default async function DashboardPage() {
-  const res = await fetch('/api/users/me', { cache: 'no-store' })
+  const cookieStore = cookies()
+  const token = cookieStore.get('token')?.value
+
+  const h = headers()
+  const proto = h.get('x-forwarded-proto') ?? 'http'
+  const host = h.get('host')
+  const base = `${proto}://${host}`
+
+  const res = await fetch(`${base}/api/users/me`, {
+    headers: token ? { Cookie: `token=${token}` } : undefined,
+    cache: 'no-store',
+  })
+
   if (!res.ok) {
     throw new Error('Failed to load profile')
   }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,14 +1,5 @@
-import { cookies } from 'next/headers'
-
 export default async function DashboardPage() {
-  const cookieStore = await cookies()
-  const token = cookieStore.get('token')?.value
-
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/users/me`, {
-    headers: token ? { Cookie: `token=${token}` } : undefined,
-    cache: 'no-store',
-  })
-
+  const res = await fetch('/api/users/me', { cache: 'no-store' })
   if (!res.ok) {
     throw new Error('Failed to load profile')
   }

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from 'next/headers'
+
+export default async function DashboardPage() {
+  const cookieStore = await cookies()
+  const token = cookieStore.get('token')?.value
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ''}/api/users/me`, {
+    headers: token ? { Cookie: `token=${token}` } : undefined,
+    cache: 'no-store',
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to load profile')
+  }
+
+  const me = await res.json()
+
+  return (
+    <div className="card">
+      <h1 className="text-xl font-semibold mb-4">Dashboard</h1>
+      <p className="mb-2">Welcome, <span className="font-medium">{me?.name || me?.email || 'User'}</span></p>
+      <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">{JSON.stringify(me, null, 2)}</pre>
+      <form action="/api/auth/logout" method="post" className="mt-4">
+        <button className="button" type="submit">Logout</button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,33 +1,32 @@
-import { cookies, headers } from 'next/headers'
+import { fetchMe } from '@/lib/auth'
+import { Button } from '@/components/Button'
+
+async function logout() {
+  'use server'
+  await fetch('/api/auth/logout', { method: 'POST' })
+}
 
 export default async function DashboardPage() {
-  const cookieStore = cookies()
-  const token = cookieStore.get('token')?.value
-
-  const h = headers()
-  const proto = h.get('x-forwarded-proto') ?? 'http'
-  const host = h.get('host')
-  const base = `${proto}://${host}`
-
-  const res = await fetch(`${base}/api/users/me`, {
-    headers: token ? { Cookie: `token=${token}` } : undefined,
-    cache: 'no-store',
-  })
-
-  if (!res.ok) {
-    throw new Error('Failed to load profile')
-  }
-
-  const me = await res.json()
+  const me = await fetchMe()
 
   return (
-    <div className="card">
-      <h1 className="text-xl font-semibold mb-4">Dashboard</h1>
-      <p className="mb-2">Welcome, <span className="font-medium">{me?.name || me?.email || 'User'}</span></p>
-      <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">{JSON.stringify(me, null, 2)}</pre>
-      <form action="/api/auth/logout" method="post" className="mt-4">
-        <button className="button" type="submit">Logout</button>
-      </form>
+    <div className="mx-auto max-w-2xl p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      {me ? (
+        <div className="space-y-2">
+          <p>
+            Logged in as: <span className="font-mono">{me.email || me.username || me.name}</span>
+          </p>
+          <pre className="p-4 bg-gray-100 rounded text-sm overflow-auto">
+{JSON.stringify(me, null, 2)}
+          </pre>
+          <form action={logout}>
+            <Button type="submit">Logout</Button>
+          </form>
+        </div>
+      ) : (
+        <p>Not authenticated.</p>
+      )}
     </div>
   )
 }

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+export default function Error({ error }: { error: Error & { digest?: string } }) {
+  return (
+    <div className="card">
+      <h1 className="text-xl font-semibold mb-2">Something went wrong</h1>
+      <pre className="bg-gray-100 p-3 rounded text-sm overflow-auto">{error?.message}</pre>
+    </div>
+  )
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, :root {
+  height: 100%;
+}
+
+.container {
+  @apply max-w-md mx-auto p-6;
+}
+
+.card {
+  @apply bg-white rounded-lg shadow p-6 border border-gray-200;
+}
+
+.input {
+  @apply w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500;
+}
+
+.button {
+  @apply w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50;
+}
+
+.link {
+  @apply text-blue-600 hover:underline;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,26 +2,31 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body, :root {
+:root {
+  --bg: #0b1020;
+}
+
+html, body, #__next {
   height: 100%;
 }
 
-.container {
-  @apply max-w-md mx-auto p-6;
+body {
+  background: var(--bg);
+  color: white;
 }
 
-.card {
-  @apply bg-white rounded-lg shadow p-6 border border-gray-200;
+.container-auth {
+  @apply max-w-md mx-auto p-6 bg-white/5 rounded-lg shadow border border-white/10;
 }
 
 .input {
-  @apply w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500;
+  @apply w-full rounded-md border border-white/20 bg-white/5 p-2 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-blue-500;
 }
 
-.button {
-  @apply w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50;
+.btn {
+  @apply inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 disabled:opacity-50;
 }
 
 .link {
-  @apply text-blue-600 hover:underline;
+  @apply text-blue-400 hover:text-blue-300 underline;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import './globals.css'
+import '../styles/globals.css'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+import './globals.css'
+
+export const metadata: Metadata = {
+  title: 'Frontend',
+  description: 'Next.js frontend integrated with backend auth',
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-900">
+        <main className="container py-10">{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,17 +1,19 @@
-import type { Metadata } from 'next'
 import './globals.css'
+import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Frontend',
+  title: 'Abhishek App',
   description: 'Next.js frontend integrated with backend auth',
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-50 text-gray-900">
-        <main className="container py-10">{children}</main>
-      </body>
+      <body className="min-h-screen antialiased">{children}</body>
     </html>
   )
 }

--- a/frontend/src/app/loading.tsx
+++ b/frontend/src/app/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="card">
+      <p>Loading...</p>
+    </div>
+  )
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="card">
+      <h1 className="text-xl font-semibold mb-2">404 - Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  )
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,15 +1,8 @@
-import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getSession } from '@/lib/auth'
 
 export default function HomePage() {
-  return (
-    <div className="card">
-      <h1 className="text-xl font-semibold mb-4">Welcome</h1>
-      <p className="mb-4">This is a minimal Next.js app integrated with backend auth.</p>
-      <div className="flex gap-3">
-        <Link className="link" href="/login">Login</Link>
-        <Link className="link" href="/register">Register</Link>
-        <Link className="link" href="/dashboard">Dashboard</Link>
-      </div>
-    </div>
-  )
+  const { token } = getSession()
+  if (token) redirect('/dashboard')
+  redirect('/login')
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <div className="card">
+      <h1 className="text-xl font-semibold mb-4">Welcome</h1>
+      <p className="mb-4">This is a minimal Next.js app integrated with backend auth.</p>
+      <div className="flex gap-3">
+        <Link className="link" href="/login">Login</Link>
+        <Link className="link" href="/register">Register</Link>
+        <Link className="link" href="/dashboard">Dashboard</Link>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,22 +1,21 @@
 import React from 'react'
-import clsx from 'clsx'
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   loading?: boolean
 }
 
 export const Button: React.FC<Props> = ({
-  className,
+  className = '',
   children,
   disabled,
   loading,
   ...rest
 }) => (
   <button
-    className={clsx(
-      'px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50',
+    className={
+      'px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 ' +
       className
-    )}
+    }
     disabled={disabled || loading}
     {...rest}
   >

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import clsx from 'clsx'
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  loading?: boolean
+}
+
+export const Button: React.FC<Props> = ({
+  className,
+  children,
+  disabled,
+  loading,
+  ...rest
+}) => (
+  <button
+    className={clsx(
+      'px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50',
+      className
+    )}
+    disabled={disabled || loading}
+    {...rest}
+  >
+    {loading ? 'Loading…' : children}
+  </button>
+)

--- a/frontend/src/components/FormInput.tsx
+++ b/frontend/src/components/FormInput.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { FieldError } from 'react-hook-form'
+
+type Props = React.InputHTMLAttributes<HTMLInputElement> & {
+  label: string
+  name: string
+  error?: FieldError
+}
+
+export default function FormInput({ label, name, error, ...rest }: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={name} className="text-sm font-medium">
+        {label}
+      </label>
+      <input
+        id={name}
+        name={name}
+        className="border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        {...rest}
+      />
+      {error && (
+        <p className="text-sm text-red-600" role="alert">
+          {error.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Navbar() {
+  return (
+    <nav className="w-full border-b bg-white">
+      <div className="mx-auto max-w-4xl px-4 py-3 flex items-center justify-between">
+        <Link href="/" className="font-semibold">
+          Abhishek App
+        </Link>
+        <div className="flex gap-4 text-sm">
+          <Link href="/login">Login</Link>
+          <Link href="/register">Register</Link>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000'

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,21 @@
+import { cookies } from 'next/headers'
+import { API_BASE_URL } from './env'
+
+export function getSession() {
+  const cookieStore = cookies()
+  const token = cookieStore.get('token')?.value
+  return { token }
+}
+
+export async function fetchMe(token?: string) {
+  const authToken = token ?? getSession().token
+  if (!authToken) return null
+  const res = await fetch(`${API_BASE_URL}/users/me`, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+    cache: 'no-store',
+  })
+  if (!res.ok) return null
+  return res.json()
+}

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000'

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('token')?.value
+  const isAuthPath = req.nextUrl.pathname.startsWith('/login') || req.nextUrl.pathname.startsWith('/register')
+  const isProtected = req.nextUrl.pathname.startsWith('/dashboard')
+
+  if (!token && isProtected) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/login'
+    url.searchParams.set('next', req.nextUrl.pathname)
+    return NextResponse.redirect(url)
+  }
+
+  if (token && isAuthPath) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/dashboard'
+    return NextResponse.redirect(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/login', '/register', '/dashboard'],
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, :root {
+  height: 100%;
+}
+
+body {
+  @apply bg-gray-50 text-gray-900;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -2,9 +2,8 @@ import type { Config } from 'tailwindcss'
 
 const config: Config = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {},

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,13 +1,13 @@
 import type { Config } from 'tailwindcss'
 
-const config: Config = {
+export default {
   content: [
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {},
   },
   plugins: [],
-}
-export default config
+} satisfies Config

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,13 +1,28 @@
 import type { Config } from 'tailwindcss'
 
-export default {
+const config: Config = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          50: '#eef2ff',
+          100: '#e0e7ff',
+          200: '#c7d2fe',
+          300: '#a5b4fc',
+          400: '#818cf8',
+          500: '#6366f1',
+          600: '#4f46e5',
+          700: '#4338ca',
+          800: '#3730a3',
+          900: '#312e81'
+        }
+      }
+    }
   },
   plugins: [],
-} satisfies Config
+}
+export default config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,25 +1,28 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "jsxImportSource": "react",
+    "incremental": true,
+    "plugins": [
+      { "name": "next" }
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["src/components/*"],
-      "@/lib/*": ["src/lib/*"]
-    },
-    "types": ["node"]
+      "@/components/*": ["./components/*"],
+      "@/lib/*": ["./lib/*"]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
     "skipLibCheck": true,
@@ -21,7 +21,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "forceConsistentCasingInFileNames": true
+    "types": ["node"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,28 +1,25 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "es2022"],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
+    "jsxImportSource": "react",
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/components/*": ["src/components/*"],
+      "@/lib/*": ["src/lib/*"]
     },
     "types": ["node"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR introduces a new Thank You page for the Next.js frontend (App Router) at /thankyou.

Highlights:
- New route: frontend/app/thankyou/page.tsx with an attractive, responsive UI built with Tailwind CSS.
- Lightweight, CSS-based confetti effect (no heavy dependencies) via a local CSS module: frontend/app/thankyou/confetti.module.css.
- Metadata included: export const metadata = { title: 'Thank You' }.
- Clear call-to-actions: 
  - "Go to Dashboard" -> /dashboard
  - "Back to Home" -> /
- Optional navbar enhancement: adds a subtle Thank You link in frontend/components/ui/navbar.tsx (hidden on small screens to avoid layout shifts).

Screenshots (placeholders):
- thankyou-desktop.png
- thankyou-mobile.png

How to test:
1. npm i && npm run dev (in /frontend)
2. Navigate to http://localhost:3001/thankyou
3. Verify page renders with confetti animation, headline, description, and both navigation buttons.

No new dependencies or database changes.
