### PR TITLE
feat(snake-game): UI/UX refresh, mouse speed/brake, optional AI snake, tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,34 @@
 
 ### 🚀 Full Stack Developer | AI Enthusiast
 
-Passionate about building modern applications and exploring AI-powered solutions.  
+Passionate about building modern applications and exploring AI-powered solutions.
 I enjoy creating impactful projects, solving problems, and continuously learning new things.
 
 ⭐ Building, learning, and growing every day.
 
 ---
 
-Note: A new Vite + React Snake Game lives under snake-game/ with:
-- Modern UI (grid, rounded cells, light/dark)
-- Mouse controls (left: speed up, right: brake)
-- Optional AI snake and tests (Vitest)
+## 🎮 Snake Game — Vite + React (in `snake-game/`)
+A modern take on the classic Snake, built with Vite + React and TypeScript.
 
-Run it:
-- cd snake-game && npm install
-- npm run dev (or npm test)
+Features:
+- UI refresh with polished grid, rounded cells, and light/dark theme
+- Mouse controls: left-click to boost, right-click to brake (prevents context menu)
+- Optional AI snake with simple pathing and timed respawn after collisions
+- Tests with Vitest (AI behavior, collisions, mouse speed/brake logic)
+
+Getting started:
+- Run dev server:
+  - cd snake-game
+  - npm install
+  - npm run dev
+- Run tests:
+  - npm test
+  - npm run test:watch
+- Build preview:
+  - npm run build
+  - npm run preview
+
+Notes:
+- The app supports keyboard controls: Space (pause), Arrow keys (turn), R (reset)
+- The high score persists locally via localStorage

--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Passionate about building modern applications and exploring AI-powered solutions
 I enjoy creating impactful projects, solving problems, and continuously learning new things.
 
 ⭐ Building, learning, and growing every day.
+
+---
+
+Note: A new Vite + React Snake Game lives under snake-game/ with:
+- Modern UI (grid, rounded cells, light/dark)
+- Mouse controls (left: speed up, right: brake)
+- Optional AI snake and tests (Vitest)
+
+Run it:
+- cd snake-game && npm install
+- npm run dev (or npm test)

--- a/snake-game/index.html
+++ b/snake-game/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snake Game</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/snake-game/index.html
+++ b/snake-game/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Snake Game</title>
+    <title>Snake Game — Vite + React</title>
   </head>
   <body>
     <div id="root"></div>

--- a/snake-game/package.json
+++ b/snake-game/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "snake-game",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "typescript": "^5.5.3",
+    "vite": "^5.3.1",
+    "vitest": "^1.6.0"
+  }
+}

--- a/snake-game/package.json
+++ b/snake-game/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest --run"
+    "test": "vitest --run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -16,6 +17,8 @@
   "devDependencies": {
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.3.1",
+    "@testing-library/jest-dom": "^6.4.8",
     "typescript": "^5.5.3",
     "vite": "^5.3.1",
     "vitest": "^1.6.0"

--- a/snake-game/package.json
+++ b/snake-game/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest --run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -15,10 +16,11 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.8",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.3.1",
-    "@testing-library/jest-dom": "^6.4.8",
+    "jsdom": "^24.1.0",
     "typescript": "^5.5.3",
     "vite": "^5.3.1",
     "vitest": "^1.6.0"

--- a/snake-game/src/App.tsx
+++ b/snake-game/src/App.tsx
@@ -1,0 +1,1 @@
+export { App as default } from './ui/App'

--- a/snake-game/src/main.tsx
+++ b/snake-game/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { App } from './ui/App'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/snake-game/src/styles.css
+++ b/snake-game/src/styles.css
@@ -1,0 +1,48 @@
+:root {
+  --bg: #0f172a;
+  --fg: #e2e8f0;
+  --panel: #111827;
+  --accent: #22d3ee;
+  --player: #34d399;
+  --ai: #f472b6;
+  --food: #f59e0b;
+  --cell: #1f2937;
+  --grid: rgba(255,255,255,.05);
+}
+.theme-light {
+  --bg: #f8fafc;
+  --fg: #0f172a;
+  --panel: #ffffffcc;
+  --accent: #0ea5e9;
+  --player: #16a34a;
+  --ai: #db2777;
+  --food: #d97706;
+  --cell: #e5e7eb;
+  --grid: rgba(0,0,0,.06);
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body { margin: 0; background: var(--bg); color: var(--fg); font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, sans-serif; }
+
+.app { display: grid; grid-template-rows: auto 1fr auto; gap: 12px; padding: 16px; max-width: 900px; margin: 0 auto; }
+.hud { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; justify-content: space-between; background: var(--panel); padding: 10px 12px; border-radius: 12px; box-shadow: 0 6px 24px rgba(0,0,0,.2); }
+.hud .scores { display: flex; gap: 14px; font-weight: 600; }
+.hud .controls { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+.hud label { display: flex; align-items: center; gap: 6px; font-size: .9rem; background: rgba(0,0,0,.06); padding: 6px 8px; border-radius: 8px; }
+.hud select, .hud input[type="range"], .hud input[type="checkbox"], .hud button { accent-color: var(--accent); }
+.hud button { background: var(--accent); color: #002; border: none; padding: 6px 10px; border-radius: 8px; font-weight: 700; cursor: pointer; }
+
+main { display: grid; place-items: center; }
+.board { display: grid; gap: 2px; padding: 14px; background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(0,0,0,.08)); border-radius: 16px; box-shadow: inset 0 1px 0 rgba(255,255,255,.05), 0 10px 30px rgba(0,0,0,.3); touch-action: none; }
+.cell { width: 22px; height: 22px; background: var(--cell); border-radius: 6px; box-shadow: 0 1px 0 rgba(255,255,255,.05), inset 0 1px 2px rgba(0,0,0,.25); outline: 1px solid var(--grid); }
+.cell.player { background: linear-gradient(180deg, var(--player), color-mix(in oklab, var(--player), black 18%)); }
+.cell.ai { background: linear-gradient(180deg, var(--ai), color-mix(in oklab, var(--ai), black 18%)); }
+.cell.food { background: radial-gradient(circle at 30% 30%, #fff6, transparent 40%), var(--food); box-shadow: 0 0 0 2px color-mix(in oklab, var(--food), black 20%) inset, 0 2px 10px color-mix(in oklab, var(--food), black 30%); }
+
+footer.tips { text-align: center; opacity: .8; font-size: .9rem; }
+
+@media (max-width: 640px) {
+  .app { padding: 8px; }
+  .hud { gap: 8px; }
+}

--- a/snake-game/src/ui/App.tsx
+++ b/snake-game/src/ui/App.tsx
@@ -1,0 +1,135 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getNextDirectionAI, type Cell, type Direction, type GameState, initialGameState, stepGame, turnLeft, turnRight } from '../util/game'
+
+export function App() {
+  const [state, setState] = useState<GameState>(() => initialGameState())
+  const [isRunning, setIsRunning] = useState(true)
+  const [mouseAccel, setMouseAccel] = useState<'normal'|'fast'|'slow'>('normal')
+
+  const intervalRef = useRef<number | null>(null)
+
+  const effectiveInterval = useMemo(() => {
+    const base = state.settings.speedMs
+    if (mouseAccel === 'fast') return Math.max(50, Math.round(base * 0.5)) // ~fast
+    if (mouseAccel === 'slow') return Math.min(400, Math.round(base * 1.6)) // brake
+    return base
+  }, [mouseAccel, state.settings.speedMs])
+
+  const tick = useCallback(() => {
+    setState((s) => stepGame(s))
+  }, [])
+
+  useEffect(() => {
+    if (!isRunning) return
+    if (intervalRef.current) window.clearInterval(intervalRef.current)
+    intervalRef.current = window.setInterval(tick, effectiveInterval)
+    return () => {
+      if (intervalRef.current) window.clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [tick, effectiveInterval, isRunning])
+
+  // Keyboard controls
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === ' ') {
+        setIsRunning(r => !r)
+        return
+      }
+      if (e.key === 'ArrowLeft') setState(s => ({...s, player: {...s.player, dir: turnLeft(s.player.dir)}}))
+      if (e.key === 'ArrowRight') setState(s => ({...s, player: {...s.player, dir: turnRight(s.player.dir)}}))
+      if (e.key === 'r') setState(() => initialGameState({ keepHighScore: true }))
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    if (e.button === 0) setMouseAccel('fast')
+    if (e.button === 2) setMouseAccel('slow')
+  }
+  const onMouseUp = () => setMouseAccel('normal')
+  const onContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault()
+  }
+
+  const cellSize = useMemo(() => {
+    const maxPx = Math.min(window.innerWidth, 520) - 40
+    return Math.floor(maxPx / state.settings.cols)
+  }, [state.settings.cols])
+
+  return (
+    <div className={`app theme-${state.settings.theme}`}>
+      <header className="hud">
+        <div className="scores">
+          <span>Score: {state.score}</span>
+          <span>High: {state.highScore}</span>
+          {state.settings.aiEnabled && <span>AI length: {state.ai.alive ? state.ai.body.length : 0}</span>}
+          <span>{isRunning ? 'Running' : 'Paused'}{state.gameOver ? ' • Game Over' : ''}</span>
+        </div>
+        <div className="controls">
+          <label>
+            AI
+            <input type="checkbox" checked={state.settings.aiEnabled} onChange={e => setState(s => ({...s, settings: {...s.settings, aiEnabled: e.target.checked}}))} />
+          </label>
+          <label>
+            Theme
+            <select value={state.settings.theme} onChange={e => setState(s => ({...s, settings: {...s.settings, theme: e.target.value as any}}))}>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </label>
+          <label>
+            Size
+            <input type="range" min={12} max={30} value={state.settings.cols} onChange={e => setState(s => initialGameState({
+              cols: Number(e.target.value),
+              rows: Number(e.target.value),
+              keepHighScore: true,
+              speedMs: s.settings.speedMs,
+              aiEnabled: s.settings.aiEnabled,
+              theme: s.settings.theme,
+            }))} />
+          </label>
+          <label>
+            Speed
+            <input type="range" min={80} max={260} step={10} value={state.settings.speedMs} onChange={e => setState(s => ({...s, settings: {...s.settings, speedMs: Number(e.target.value)}}))} />
+          </label>
+          <button onClick={() => setIsRunning(r => !r)}>{isRunning ? 'Pause' : 'Resume'}</button>
+          <button onClick={() => setState(() => initialGameState({ keepHighScore: true, ...state.settings }))}>Reset</button>
+        </div>
+      </header>
+      <main>
+        <div
+          className="board"
+          style={{
+            gridTemplateColumns: `repeat(${state.settings.cols}, ${cellSize}px)`,
+            gridTemplateRows: `repeat(${state.settings.rows}, ${cellSize}px)`
+          }}
+          onMouseDown={onMouseDown}
+          onMouseUp={onMouseUp}
+          onMouseLeave={onMouseUp}
+          onContextMenu={onContextMenu}
+          role="application"
+          aria-label="Snake board"
+        >
+          {Array.from({ length: state.settings.rows }).map((_, r) =>
+            Array.from({ length: state.settings.cols }).map((_, c) => {
+              const cell: Cell = { r, c }
+              const isFood = state.food.r === r && state.food.c === c
+              const isPlayer = state.player.body.some(p => p.r === r && p.c === c)
+              const isAI = state.settings.aiEnabled && state.ai.alive && state.ai.body.some(p => p.r === r && p.c === c)
+              const classes = [
+                'cell',
+                isFood ? 'food' : '',
+                isPlayer ? 'player' : '',
+                isAI ? 'ai' : '',
+              ].filter(Boolean).join(' ')
+              return <div key={`${r}-${c}`} className={classes} />
+            })
+          )}
+        </div>
+      </main>
+      <footer className="tips">Left click: speed up • Right click: brake • Space: pause • Arrows: turn • R: reset</footer>
+    </div>
+  )
+}

--- a/snake-game/src/ui/App.tsx
+++ b/snake-game/src/ui/App.tsx
@@ -1,18 +1,16 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { getNextDirectionAI, type Cell, type Direction, type GameState, initialGameState, stepGame, turnLeft, turnRight } from '../util/game'
+import { computeEffectiveInterval, getNextDirectionAI, type Cell, type Direction, type GameState, initialGameState, stepGame, turnLeft, turnRight, type MouseAccel } from '../util/game'
 
 export function App() {
   const [state, setState] = useState<GameState>(() => initialGameState())
   const [isRunning, setIsRunning] = useState(true)
-  const [mouseAccel, setMouseAccel] = useState<'normal'|'fast'|'slow'>('normal')
+  const [mouseAccel, setMouseAccel] = useState<MouseAccel>('normal')
+  const downButtons = useRef<Set<number>>(new Set())
 
   const intervalRef = useRef<number | null>(null)
 
   const effectiveInterval = useMemo(() => {
-    const base = state.settings.speedMs
-    if (mouseAccel === 'fast') return Math.max(50, Math.round(base * 0.5)) // ~fast
-    if (mouseAccel === 'slow') return Math.min(400, Math.round(base * 1.6)) // brake
-    return base
+    return computeEffectiveInterval(state.settings.speedMs, mouseAccel)
   }, [mouseAccel, state.settings.speedMs])
 
   const tick = useCallback(() => {
@@ -38,17 +36,31 @@ export function App() {
       }
       if (e.key === 'ArrowLeft') setState(s => ({...s, player: {...s.player, dir: turnLeft(s.player.dir)}}))
       if (e.key === 'ArrowRight') setState(s => ({...s, player: {...s.player, dir: turnRight(s.player.dir)}}))
-      if (e.key === 'r') setState(() => initialGameState({ keepHighScore: true }))
+      if (e.key === 'r') setState(() => initialGameState({ keepHighScore: true, ...state.settings }))
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [])
+  }, [state.settings])
+
+  const recomputeMouseAccel = () => {
+    const s = downButtons.current
+    if (s.has(2)) setMouseAccel('slow')
+    else if (s.has(0)) setMouseAccel('fast')
+    else setMouseAccel('normal')
+  }
 
   const onMouseDown = (e: React.MouseEvent) => {
-    if (e.button === 0) setMouseAccel('fast')
-    if (e.button === 2) setMouseAccel('slow')
+    downButtons.current.add(e.button)
+    recomputeMouseAccel()
   }
-  const onMouseUp = () => setMouseAccel('normal')
+  const onMouseUp = (e: React.MouseEvent) => {
+    downButtons.current.delete(e.button)
+    recomputeMouseAccel()
+  }
+  const onMouseLeave = () => {
+    downButtons.current.clear()
+    setMouseAccel('normal')
+  }
   const onContextMenu = (e: React.MouseEvent) => {
     e.preventDefault()
   }
@@ -107,7 +119,7 @@ export function App() {
           }}
           onMouseDown={onMouseDown}
           onMouseUp={onMouseUp}
-          onMouseLeave={onMouseUp}
+          onMouseLeave={onMouseLeave}
           onContextMenu={onContextMenu}
           role="application"
           aria-label="Snake board"

--- a/snake-game/src/ui/README.md
+++ b/snake-game/src/ui/README.md
@@ -1,0 +1,26 @@
+# Snake Game (Vite + React)
+
+Controls
+- Arrow Left/Right: Turn
+- Space: Pause/Resume
+- R: Reset
+- Mouse: Hold Left to speed up, hold Right to brake (context menu disabled on the board)
+
+Settings
+- Toggle AI snake (default on)
+- Board size and speed sliders
+- Light/Dark theme
+
+AI
+- Greedy Manhattan towards food when safe
+- Avoids immediate collisions with walls or snakes; falls back to first safe alternative
+- If AI dies (wall/self/player), it respawns after a short delay and does not affect player score
+
+Run
+- npm install
+- npm run dev
+- npm test (Vitest)
+
+Build
+- npm run build
+- npm run preview

--- a/snake-game/src/util/game.ts
+++ b/snake-game/src/util/game.ts
@@ -27,6 +27,13 @@ export type GameState = {
   aiRespawnIn: number
 }
 
+export type MouseAccel = 'normal'|'fast'|'slow'
+export function computeEffectiveInterval(base: number, accel: MouseAccel): number {
+  if (accel === 'fast') return Math.max(50, Math.round(base * 0.5))
+  if (accel === 'slow') return Math.min(400, Math.round(base * 1.6))
+  return base
+}
+
 const DIRS: Record<Direction, Cell> = {
   up: { r: -1, c: 0 },
   down: { r: 1, c: 0 },

--- a/snake-game/src/util/game.ts
+++ b/snake-game/src/util/game.ts
@@ -1,0 +1,194 @@
+export type Cell = { r: number; c: number }
+export type Direction = 'up' | 'down' | 'left' | 'right'
+
+export type Snake = {
+  body: Cell[]
+  dir: Direction
+  alive: boolean
+}
+
+export type Settings = {
+  rows: number
+  cols: number
+  speedMs: number
+  aiEnabled: boolean
+  theme: 'light' | 'dark'
+}
+
+export type GameState = {
+  settings: Settings
+  player: Snake
+  ai: Snake
+  food: Cell
+  score: number
+  highScore: number
+  gameOver: boolean
+  // Internal respawn timer for AI when dead
+  aiRespawnIn: number
+}
+
+const DIRS: Record<Direction, Cell> = {
+  up: { r: -1, c: 0 },
+  down: { r: 1, c: 0 },
+  left: { r: 0, c: -1 },
+  right: { r: 0, c: 1 },
+}
+
+export function turnLeft(d: Direction): Direction {
+  switch (d) {
+    case 'up': return 'left'
+    case 'left': return 'down'
+    case 'down': return 'right'
+    case 'right': return 'up'
+  }
+}
+export function turnRight(d: Direction): Direction {
+  switch (d) {
+    case 'up': return 'right'
+    case 'right': return 'down'
+    case 'down': return 'left'
+    case 'left': return 'up'
+  }
+}
+
+function eq(a: Cell, b: Cell) { return a.r === b.r && a.c === b.c }
+
+function inBounds(s: Settings, p: Cell) {
+  return p.r >= 0 && p.c >= 0 && p.r < s.rows && p.c < s.cols
+}
+
+export function initialGameState(opts?: Partial<Settings & { keepHighScore?: boolean }>): GameState {
+  const settings: Settings = {
+    rows: opts?.rows ?? 20,
+    cols: opts?.cols ?? 20,
+    speedMs: opts?.speedMs ?? 140,
+    aiEnabled: opts?.aiEnabled ?? true,
+    theme: opts?.theme ?? 'light'
+  }
+  const center: Cell = { r: Math.floor(settings.rows/2), c: Math.floor(settings.cols/2) }
+  const player: Snake = { body: [center], dir: 'right', alive: true }
+  const ai: Snake = { body: [{ r: 1, c: 1 }], dir: 'right', alive: true }
+  const food = randomEmptyCell(settings, [player.body, ai.body])
+  const high = (opts as any)?.keepHighScore ? (typeof localStorage !== 'undefined' ? Number(localStorage.getItem('snakeHigh') || 0) : 0) : 0
+  return { settings, player, ai, food, score: 0, highScore: high, gameOver: false, aiRespawnIn: 0 }
+}
+
+export function randomEmptyCell(settings: Settings, occupiedGroups: Cell[][]): Cell {
+  const occ = new Set(occupiedGroups.flat().map(p => `${p.r}:${p.c}`))
+  const free: Cell[] = []
+  for (let r=0;r<settings.rows;r++) for (let c=0;c<settings.cols;c++) {
+    if (!occ.has(`${r}:${c}`)) free.push({ r, c })
+  }
+  return free[Math.floor(Math.random()*free.length)]
+}
+
+function willCollide(settings: Settings, next: Cell, snakes: Snake[], ignore?: Snake) {
+  if (!inBounds(settings, next)) return true
+  for (const s of snakes) {
+    if (ignore && s === ignore) continue
+    if (s.alive && s.body.some(p => eq(p, next))) return true
+  }
+  return false
+}
+
+function advanceSnake(snake: Snake, nextHead: Cell, grow: boolean): Snake {
+  const newBody = [nextHead, ...snake.body]
+  if (!grow) newBody.pop()
+  return { ...snake, body: newBody }
+}
+
+function manhattan(a: Cell, b: Cell) { return Math.abs(a.r-b.r)+Math.abs(a.c-b.c) }
+
+export function getNextDirectionAI(gs: GameState): Direction {
+  const s = gs.ai
+  if (!s.alive) return s.dir
+  const dirs: Direction[] = ['up','down','left','right']
+  // Greedy towards food
+  dirs.sort((a,b) => manhattan(applyDir(s.body[0], a), gs.food) - manhattan(applyDir(s.body[0], b), gs.food))
+
+  const candidates: Direction[] = [...new Set([
+    // forward greedy options first
+    dirs[0], dirs[1],
+    // then maintain
+    s.dir,
+    // then left/right relative as fallback
+    turnLeft(s.dir), turnRight(s.dir)
+  ])]
+
+  for (const d of candidates) {
+    const nh = applyDir(s.body[0], d)
+    if (!willCollide(gs.settings, nh, [gs.player, gs.ai])) {
+      return d
+    }
+  }
+  // if none safe, keep direction if possible else any safe
+  const forward = applyDir(s.body[0], s.dir)
+  if (!willCollide(gs.settings, forward, [gs.player, gs.ai])) return s.dir
+  for (const d of ['up','down','left','right'] as Direction[]) {
+    const nh = applyDir(s.body[0], d)
+    if (!willCollide(gs.settings, nh, [gs.player, gs.ai])) return d
+  }
+  return s.dir
+}
+
+function applyDir(p: Cell, d: Direction): Cell {
+  const off = DIRS[d]
+  return { r: p.r + off.r, c: p.c + off.c }
+}
+
+export function stepGame(gs: GameState): GameState {
+  if (gs.gameOver) return gs
+  let state = { ...gs }
+
+  // AI respawn timer
+  if (!state.ai.alive && state.aiRespawnIn > 0) {
+    state.aiRespawnIn -= 1
+    return state
+  }
+  if (!state.ai.alive && state.aiRespawnIn <= 0 && state.settings.aiEnabled) {
+    // respawn at safe random location
+    const pos = randomEmptyCell(state.settings, [state.player.body])
+    state.ai = { body: [pos], dir: 'right', alive: true }
+  }
+
+  // Compute next directions
+  const playerNext = applyDir(state.player.body[0], state.player.dir)
+  const aiDir = state.settings.aiEnabled ? getNextDirectionAI(state) : state.ai.dir
+  const aiNext = applyDir(state.ai.body[0], aiDir)
+
+  // Collisions for player
+  const playerCollision = willCollide(state.settings, playerNext, [state.player, state.ai], undefined)
+  if (playerCollision) {
+    state.gameOver = true
+    state.highScore = Math.max(state.highScore, state.score)
+    if (typeof localStorage !== 'undefined') localStorage.setItem('snakeHigh', String(state.highScore))
+    return state
+  }
+
+  // Collisions for AI
+  const aiCollision = state.settings.aiEnabled && willCollide(state.settings, aiNext, [state.player, state.ai], undefined)
+
+  const playerGrow = eq(playerNext, state.food)
+  const aiGrow = state.settings.aiEnabled && eq(aiNext, state.food)
+
+  state.player = advanceSnake(state.player, playerNext, playerGrow)
+
+  if (state.settings.aiEnabled) {
+    if (aiCollision) {
+      state.ai = { ...state.ai, alive: false }
+      state.aiRespawnIn = 8 // short delay
+    } else {
+      state.ai = advanceSnake({ ...state.ai, dir: aiDir }, aiNext, aiGrow)
+    }
+  }
+
+  // Food eaten rules: if both try to eat, prioritize player, then spawn new food
+  if (playerGrow || aiGrow) {
+    if (playerGrow) state.score += 1
+    const occupied = [state.player.body]
+    if (state.settings.aiEnabled && state.ai.alive) occupied.push(state.ai.body)
+    state.food = randomEmptyCell(state.settings, occupied)
+  }
+
+  return state
+}

--- a/snake-game/src/vite-env.d.ts
+++ b/snake-game/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/snake-game/tests/ai.spec.ts
+++ b/snake-game/tests/ai.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { GameState, initialGameState, getNextDirectionAI } from '../src/util/game'
+
+function makeState(): GameState {
+  const s = initialGameState({ rows: 6, cols: 6, aiEnabled: true })
+  // place player somewhere safe
+  s.player.body = [{ r: 3, c: 3 }]
+  s.player.dir = 'left'
+  // place ai near a wall with food to the right but wall ahead to test avoidance
+  s.ai.body = [{ r: 0, c: 2 }]
+  s.ai.dir = 'up'
+  s.food = { r: 0, c: 4 }
+  return s
+}
+
+describe('AI', () => {
+  it('chooses non-colliding move when one exists', () => {
+    const s = makeState()
+    // moving up would collide with wall; right is towards food and safe
+    const dir = getNextDirectionAI(s)
+    expect(dir).not.toBe('up')
+    expect(['right','left','down'].includes(dir)).toBe(true)
+  })
+})

--- a/snake-game/tests/collisions.spec.ts
+++ b/snake-game/tests/collisions.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { initialGameState, stepGame } from '../src/util/game'
+
+describe('Player vs AI collision', () => {
+  it('leads to game over for player', () => {
+    const s = initialGameState({ rows: 5, cols: 5, aiEnabled: true })
+    // Put player and AI facing each other
+    s.player.body = [{ r: 2, c: 2 }]
+    s.player.dir = 'right'
+    s.ai.body = [{ r: 2, c: 3 }]
+    s.ai.dir = 'left'
+    s.food = { r: 0, c: 0 }
+
+    const s2 = stepGame(s)
+    expect(s2.gameOver).toBe(true)
+  })
+})

--- a/snake-game/tests/mouse-controls.spec.ts
+++ b/snake-game/tests/mouse-controls.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { computeEffectiveInterval } from '../src/util/game'
+
+describe('Mouse controls interval', () => {
+  it('speeds up on left hold', () => {
+    expect(computeEffectiveInterval(140, 'fast')).toBeLessThan(140)
+  })
+  it('brakes on right hold', () => {
+    expect(computeEffectiveInterval(140, 'slow')).toBeGreaterThan(140)
+  })
+  it('normal when released', () => {
+    expect(computeEffectiveInterval(140, 'normal')).toBe(140)
+  })
+})

--- a/snake-game/tsconfig.json
+++ b/snake-game/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "vite.config.ts", "vitest.setup.ts", "tests"]
+}

--- a/snake-game/vite.config.ts
+++ b/snake-game/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts'
+  }
+})

--- a/snake-game/vitest.setup.ts
+++ b/snake-game/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
Summary
- Create a new Vite + React app under snake-game/ (vite base: ./)
- Modernized UI: grid lines, rounded cells, subtle shadows, responsive, light/dark themes
- HUD: score, high score, game state, AI length
- Settings: toggle AI (default on), board size, speed, theme
- Mouse controls: hold Left to speed up, hold Right to brake; releases return to normal; board context menu disabled
- Optional AI snake: greedy Manhattan towards food, avoids immediate collisions; distinct color; dies and respawns after a short delay without affecting player score
- Collisions: player vs wall/self/AI → Game Over; AI vs wall/self/player → AI dies and respawns later
- Tests (Vitest):
  - AI chooses a non-colliding move when one exists
  - Player vs AI collision leads to Game Over
  - Mouse controls adjust effective interval logic (unit-test state-level logic)
- Docs: updated root README to reference new features, added snake-game/README with controls and options

Run locally
- cd snake-game
- npm install
- npm run dev (open http://localhost:5173)
- npm test

Notes
- Kept changes scoped to the new snake-game directory and a small README note in the root.
- The AI toggle defaults to enabled. Mouse controls do not interfere with keyboard controls.
