### PR TITLE
feat(snake): fullscreen responsive board, AI opponents, and nature-themed polish

### DIFF
--- a/snake-game/README.md
+++ b/snake-game/README.md
@@ -1,9 +1,15 @@
 # Snake Game (Vite + React)
 
-A classic Snake game implemented with React and Vite. Keyboard controls (Arrow keys / WASD), mouse steering with boost/brake, mobile-friendly on-screen D‑pad, score with high score persistence, pause/resume, restart, and progressive speed increases.
+A classic Snake game implemented with React and Vite. Now fullscreen and nature-themed, with optional AI opponents.
+
+## What’s new
+- Fullscreen, responsive board that adapts rows/columns to your viewport. Logical tile size about 20px.
+- Multiple computer-controlled snakes (0..5). Default 3. Shared food; player gains score only on player consumption.
+- AI snakes greedily chase the nearest food using a safe-step heuristic that avoids immediate collisions and obeys the no‑reverse rule. When an AI hits a wall/body it dies and respawns after a short delay.
+- Visual polish: animated, lightweight nature gradient background; rounded snakes with subtle shading and expressive heads; distinct colors per AI.
+- Mouse mode preserved with Boost (LMB) and Brake (RMB). Toggle Mouse in the UI; context menu suppressed on the board.
 
 ## Features
-- 20x20 grid with visible cells
 - Keyboard: Arrow keys and WASD; Space/Enter to pause/resume; restart on game over
 - Mouse control (default: enabled):
   - Move mouse to steer continuously toward the cursor
@@ -13,10 +19,8 @@ A classic Snake game implemented with React and Vite. Keyboard controls (Arrow k
   - Toggle Mouse: On/Off button in the scoreboard
 - On-screen mobile controls
 - Score + High score (stored in localStorage)
-- Food spawns never on the snake body
 - Growth on eat and speed increases every few foods
-- Game over overlay for wall/self collisions
-- Responsive layout, light/dark theme via prefers-color-scheme
+- Game over overlay for wall/self/any-body collisions (player)
 - Accessible buttons with aria-labels and focus styles
 
 ## Getting started
@@ -53,6 +57,13 @@ You can also host the built files from a sub-path thanks to `vite.config.js` set
 - Right mouse: hold to Brake
 - Toggle Mouse: On/Off in the scoreboard
 - Space/Enter: pause/resume (or restart when game over)
+- Slider: choose the number of AI snakes (0..5)
+
+## AI rules
+- AI snakes seek the nearest food.
+- Immediate-collision avoidance: they prefer safe steps based on next-cell occupancy (walls, bodies) and won’t reverse.
+- If an AI collides with a wall, itself, the player, or other AI, it dies and respawns at a safe random position and direction shortly after.
+- Food is shared: any snake that reaches the food grows; new food appears. Only the player’s score increases when the player eats.
 
 ## Project structure
 ```
@@ -75,8 +86,10 @@ snake-game/
       game.js
   tests/
     game.test.js
+    ai.test.js
 ```
 
 ## Notes
-- The board background uses lightweight CSS gradients and patterns for a game-like feel without image assets.
-- The snake is rendered via CSS rounded cells with subtle shading and eye markers on the head for a more “alive” look.
+- The board background uses lightweight CSS gradients and animations for a nature feel without image assets; it’s highly performant.
+- The snake is rendered via CSS rounded cells with subtle shading and eye markers on the head for a more “alive” look. AI snakes have distinct colors.
+- The board scales to fill your screen; rows/cols are computed from the viewport with a logical tile of ~20px.

--- a/snake-game/src/App.jsx
+++ b/snake-game/src/App.jsx
@@ -9,18 +9,34 @@ import {
   initialDirection,
   moveSnake,
   nextDirectionFromKey,
-  spawnFood,
-  checkCollision,
+  spawnFoodWithOccupied,
+  rectCheckSelfOrWallCollision,
   SPEED_LEVELS,
   nextDirectionTowardTarget,
+  DIRECTIONS,
+  nextSafeDirectionTowardTarget,
+  chooseNearestFood,
+  willCollideAt,
+  spawnRandomSnake,
 } from './utils/game.js'
 
-const GRID_SIZE = 20
+const TILE_SIZE = 20 // px per logical tile (approx)
+const MAX_AI = 5
 
 export default function App() {
-  const [snake, setSnake] = useState(initialSnake)
-  const [direction, setDirection] = useState(initialDirection)
-  const [food, setFood] = useState(() => spawnFood(GRID_SIZE, initialSnake))
+  const containerRef = useRef(null)
+  const [cols, setCols] = useState(20)
+  const [rows, setRows] = useState(20)
+
+  // player state
+  const [playerSnake, setPlayerSnake] = useState(initialSnake)
+  const [playerDir, setPlayerDir] = useState(initialDirection)
+
+  // ai snakes
+  const [aiSnakes, setAiSnakes] = useState([]) // array of { id, body, direction, alive, respawnAt }
+  const [aiCount, setAiCount] = useState(3)
+
+  const [food, setFood] = useState({ x: 5, y: 5 })
   const [score, setScore] = useState(0)
   const [highScore, setHighScore] = useState(() => Number(localStorage.getItem('snake-high-score') || 0))
   const [speedLevel, setSpeedLevel] = useState(0)
@@ -32,10 +48,48 @@ export default function App() {
   const [boosting, setBoosting] = useState(false)
   const [braking, setBraking] = useState(false)
   const mouseTarget = useRef(null) // {x, y} grid coordinates
-  const boardRef = useRef(null)
 
-  const pendingDir = useRef(direction)
+  const pendingDir = useRef(playerDir)
   const foodsEaten = useRef(0)
+  const idCounter = useRef(1)
+
+  // Responsive grid based on container size
+  useEffect(() => {
+    function computeGrid() {
+      const el = containerRef.current || document.documentElement
+      const w = el.clientWidth
+      const h = el.clientHeight
+      const c = Math.max(10, Math.floor(w / TILE_SIZE))
+      const r = Math.max(10, Math.floor(h / TILE_SIZE))
+      setCols(c)
+      setRows(r)
+    }
+    computeGrid()
+    window.addEventListener('resize', computeGrid)
+    return () => window.removeEventListener('resize', computeGrid)
+  }, [])
+
+  // Setup and maintain AI snakes based on aiCount
+  useEffect(() => {
+    // Build occupied set from player only when (re)spawning
+    const occ = new Set(playerSnake.map((p) => `${p.x},${p.y}`))
+    const next = []
+    for (let i = 0; i < aiCount; i++) {
+      const { body, direction } = spawnRandomSnake(cols, rows, occ)
+      body.forEach((p) => occ.add(`${p.x},${p.y}`))
+      next.push({ id: `ai-${idCounter.current++}`, body, direction, alive: true, aiIndex: i })
+    }
+    setAiSnakes(next)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [aiCount, cols, rows])
+
+  // Recompute food when board or snakes change significantly at start
+  useEffect(() => {
+    const occ = new Set(playerSnake.map((p) => `${p.x},${p.y}`))
+    aiSnakes.forEach((s) => s.body.forEach((p) => occ.add(`${p.x},${p.y}`)))
+    setFood(spawnFoodWithOccupied(cols, rows, occ))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cols, rows])
 
   // Keyboard controls
   useEventListener('keydown', (e) => {
@@ -45,7 +99,7 @@ export default function App() {
       else togglePause()
       return
     }
-    const nd = nextDirectionFromKey(key, direction)
+    const nd = nextDirectionFromKey(key, playerDir)
     if (nd) {
       pendingDir.current = nd
     }
@@ -70,17 +124,110 @@ export default function App() {
   useInterval(() => {
     if (isPaused || isGameOver) return
 
-    // Continuous steering toward mouse target when enabled
+    // Player steering
     if (mouseEnabled && mouseTarget.current) {
-      const head = snake[0]
-      const nd = nextDirectionTowardTarget(head, direction, mouseTarget.current)
+      const head = playerSnake[0]
+      const nd = nextDirectionTowardTarget(head, playerDir, mouseTarget.current)
       if (nd) pendingDir.current = nd
     }
 
-    const newDir = pendingDir.current
-    const { newSnake, grew } = moveSnake(snake, newDir, food, GRID_SIZE)
+    let newPlayerDir = pendingDir.current
 
-    if (checkCollision(newSnake, GRID_SIZE)) {
+    // Occupancy set for collisions includes all snakes except each snake's own tail (which vacates if not growing)
+    const occupiedNow = new Set()
+    playerSnake.slice(0, -1).forEach((p) => occupiedNow.add(`${p.x},${p.y}`)) // exclude player tail by default
+    aiSnakes.forEach((s) => s.body.forEach((p, idx) => {
+      if (idx < s.body.length - 1) occupiedNow.add(`${p.x},${p.y}`)
+    }))
+
+    // Move AI snakes first using safe-step heuristic
+    const movedAIs = aiSnakes.map((s, idx) => {
+      if (!s.alive) {
+        // check for respawn
+        return s
+      }
+      const head = s.body[0]
+      const target = chooseNearestFood(head, [food]) || food
+      const willGrow = head.x + s.direction.x === food.x && head.y + s.direction.y === food.y
+      const nextDir = nextSafeDirectionTowardTarget(head, s.direction, target, {
+        cols,
+        rows,
+        occupiedSet: occupiedNow,
+        ownTail: s.body[s.body.length - 1],
+        willGrow,
+      })
+      const nextHead = { x: head.x + nextDir.x, y: head.y + nextDir.y }
+      let newBody = [nextHead, ...s.body]
+      let grew = false
+      if (nextHead.x === food.x && nextHead.y === food.y) {
+        grew = true
+      } else {
+        newBody.pop()
+      }
+      let died = false
+      // Collision vs walls, self, player, other AI bodies
+      const hitWall = nextHead.x < 0 || nextHead.y < 0 || nextHead.x >= cols || nextHead.y >= rows
+      const hitSelf = newBody.slice(1).some((p) => p.x === nextHead.x && p.y === nextHead.y)
+      const hitPlayer = playerSnake.some((p, i) => i !== playerSnake.length - 1 && p.x === nextHead.x && p.y === nextHead.y)
+      let hitOtherAI = false
+      for (let j = 0; j < aiSnakes.length; j++) {
+        if (j === idx) continue
+        const other = aiSnakes[j]
+        if (!other.alive) continue
+        // other body except tail
+        if (other.body.some((p, k) => k !== other.body.length - 1 && p.x === nextHead.x && p.y === nextHead.y)) {
+          hitOtherAI = true
+          break
+        }
+      }
+      if (hitWall || hitSelf || hitPlayer || hitOtherAI) {
+        died = true
+      }
+      return {
+        ...s,
+        body: died ? s.body : newBody,
+        direction: died ? s.direction : nextDir,
+        alive: died ? false : true,
+        // simple respawn timer via counter ticks
+        respawnIn: died ? 10 : undefined,
+        justAte: grew,
+      }
+    })
+
+    // Decrement respawn timers and respawn if needed
+    const respawnedAIs = movedAIs.map((s, i) => {
+      if (s.alive) return s
+      const rem = (s.respawnIn ?? 0) - 1
+      if (rem > 0) return { ...s, respawnIn: rem }
+      // Respawn at a safe spot
+      const occ = new Set()
+      // Occupy current player and all alive AI (after their move)
+      playerSnake.forEach((p) => occ.add(`${p.x},${p.y}`))
+      movedAIs.forEach((t, j) => {
+        if (i === j) return
+        if (t.alive) t.body.forEach((p) => occ.add(`${p.x},${p.y}`))
+      })
+      const { body, direction } = spawnRandomSnake(cols, rows, occ)
+      return { ...s, body, direction, alive: true, respawnIn: undefined }
+    })
+
+    // Now move player
+    const playerHead = playerSnake[0]
+    const nextPlayerHead = { x: playerHead.x + newPlayerDir.x, y: playerHead.y + newPlayerDir.y }
+
+    // Player collisions: walls, self, any AI body (including their new heads)
+    const hitWall = nextPlayerHead.x < 0 || nextPlayerHead.y < 0 || nextPlayerHead.x >= cols || nextPlayerHead.y >= rows
+    const hitSelf = playerSnake.slice(1).some((p) => p.x === nextPlayerHead.x && p.y === nextPlayerHead.y)
+    let hitAI = false
+    for (const s of respawnedAIs) {
+      if (!s.alive) continue
+      if (s.body.some((p) => p.x === nextPlayerHead.x && p.y === nextPlayerHead.y)) {
+        hitAI = true
+        break
+      }
+    }
+
+    if (hitWall || hitSelf || hitAI) {
       setIsGameOver(true)
       setIsPaused(true)
       setHighScore((prev) => {
@@ -91,81 +238,105 @@ export default function App() {
       return
     }
 
-    setSnake(newSnake)
-    setDirection(newDir)
-
-    if (grew) {
-      setScore((s) => s + 1)
-      foodsEaten.current += 1
-      setFood((prev) => spawnFood(GRID_SIZE, newSnake))
-      if (foodsEaten.current % 5 === 0) {
-        setSpeedLevel((l) => l + 1)
-      }
+    let grew = false
+    let newPlayerSnake = [nextPlayerHead, ...playerSnake]
+    if (nextPlayerHead.x === food.x && nextPlayerHead.y === food.y) {
+      grew = true
+    } else {
+      newPlayerSnake.pop()
     }
+
+    // If any AI also ate the same food, they grow too. Food is shared; respawn new food if consumed by anyone.
+    let foodConsumed = grew
+    const finalAIs = respawnedAIs.map((s) => {
+      if (!s.alive) return s
+      const h = s.body[0]
+      if (h.x === food.x && h.y === food.y) {
+        foodConsumed = true
+        return { ...s, body: [h, ...s.body] } // grow without dropping tail (already advanced)
+      }
+      return s
+    })
+
+    if (foodConsumed) {
+      // increment only for player eating
+      if (grew) {
+        setScore((sc) => sc + 1)
+        foodsEaten.current += 1
+        if (foodsEaten.current % 5 === 0) setSpeedLevel((l) => l + 1)
+      }
+      // Recompute occupied and spawn new food
+      const occ = new Set(newPlayerSnake.map((p) => `${p.x},${p.y}`))
+      finalAIs.forEach((s) => s.alive && s.body.forEach((p) => occ.add(`${p.x},${p.y}`)))
+      setFood(spawnFoodWithOccupied(cols, rows, occ))
+    }
+
+    setPlayerSnake(newPlayerSnake)
+    setPlayerDir(newPlayerDir)
+    setAiSnakes(finalAIs)
   }, intervalMs)
 
-  function togglePause() {
-    setIsPaused((p) => !p)
-  }
+  function togglePause() { setIsPaused((p) => !p) }
 
   function restart() {
-    setSnake(initialSnake)
-    setDirection(initialDirection)
-    setFood(spawnFood(GRID_SIZE, initialSnake))
+    setPlayerSnake(initialSnake)
+    setPlayerDir(initialDirection)
     setScore(0)
     setIsPaused(false)
     setIsGameOver(false)
     setSpeedLevel(0)
     foodsEaten.current = 0
     pendingDir.current = initialDirection
-    // keep mouse settings as-is
+    // respawn AI per current aiCount
+    const occ = new Set(initialSnake.map((p) => `${p.x},${p.y}`))
+    const next = []
+    for (let i = 0; i < aiCount; i++) {
+      const { body, direction } = spawnRandomSnake(cols, rows, occ)
+      body.forEach((p) => occ.add(`${p.x},${p.y}`))
+      next.push({ id: `ai-${idCounter.current++}`, body, direction, alive: true, aiIndex: i })
+    }
+    setAiSnakes(next)
+    // spawn food not on any snake
+    const occ2 = new Set(initialSnake.map((p) => `${p.x},${p.y}`))
+    next.forEach((s) => s.body.forEach((p) => occ2.add(`${p.x},${p.y}`)))
+    setFood(spawnFoodWithOccupied(cols, rows, occ2))
   }
 
-  // Mouse handlers
+  // Mouse handlers: map to grid coordinates based on container size
   function updateMouseTarget(ev) {
-    if (!boardRef.current) return
-    const rect = boardRef.current.getBoundingClientRect()
+    const el = containerRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
     const cx = Math.min(Math.max(ev.clientX - rect.left, 0), rect.width)
     const cy = Math.min(Math.max(ev.clientY - rect.top, 0), rect.height)
-    const gx = Math.floor((cx / rect.width) * GRID_SIZE)
-    const gy = Math.floor((cy / rect.height) * GRID_SIZE)
+    const gx = Math.floor((cx / rect.width) * cols)
+    const gy = Math.floor((cy / rect.height) * rows)
     mouseTarget.current = { x: gx, y: gy }
   }
 
-  function onMouseMove(ev) {
-    if (!mouseEnabled) return
-    updateMouseTarget(ev)
-  }
+  function onMouseMove(ev) { if (!mouseEnabled) return; updateMouseTarget(ev) }
   function onMouseDown(ev) {
     if (!mouseEnabled) return
-    // 0: left, 2: right
-    if (ev.button === 0) {
-      setBoosting(true)
-      updateMouseTarget(ev)
-    } else if (ev.button === 2) {
-      setBraking(true)
-      updateMouseTarget(ev)
-    }
+    if (ev.button === 0) { setBoosting(true); updateMouseTarget(ev) }
+    else if (ev.button === 2) { setBraking(true); updateMouseTarget(ev) }
   }
-  function onMouseUp(ev) {
-    if (ev.button === 0) setBoosting(false)
-    if (ev.button === 2) setBraking(false)
-  }
-  function onMouseLeave() {
-    setBoosting(false)
-    setBraking(false)
-  }
-  function onContextMenu(ev) {
-    // disable context menu when interacting over the board
-    ev.preventDefault()
-  }
+  function onMouseUp(ev) { if (ev.button === 0) setBoosting(false); if (ev.button === 2) setBraking(false) }
+  function onMouseLeave() { setBoosting(false); setBraking(false) }
+  function onContextMenu(ev) { ev.preventDefault() }
+
+  const snakes = useMemo(() => {
+    return [
+      { id: 'player', body: playerSnake, direction: playerDir, kind: 'player' },
+      ...aiSnakes.map((s, i) => ({ ...s, kind: 'ai', aiIndex: i })),
+    ]
+  }, [playerSnake, playerDir, aiSnakes])
 
   return (
-    <div className="app">
+    <div className="app fullscreen" ref={containerRef}>
       <header className="header">
         <h1>Snake</h1>
       </header>
-      <main className="main">
+      <main className="main fullscreen-main">
         <Scoreboard
           score={score}
           highScore={Math.max(highScore, score)}
@@ -175,25 +346,28 @@ export default function App() {
           mouseEnabled={mouseEnabled}
           onToggleMouse={() => setMouseEnabled((m) => !m)}
         />
-        <div ref={boardRef}>
-          <Board
-            gridSize={GRID_SIZE}
-            snake={snake}
-            food={food}
-            isGameOver={isGameOver}
-            direction={direction}
-            onMouseMove={onMouseMove}
-            onMouseDown={onMouseDown}
-            onMouseUp={onMouseUp}
-            onMouseLeave={onMouseLeave}
-            onContextMenu={onContextMenu}
-          />
-        </div>
+        <Board
+          cols={cols}
+          rows={rows}
+          snakes={snakes}
+          food={food}
+          isGameOver={isGameOver}
+          onMouseMove={onMouseMove}
+          onMouseDown={onMouseDown}
+          onMouseUp={onMouseUp}
+          onMouseLeave={onMouseLeave}
+          onContextMenu={onContextMenu}
+        />
         <Controls
           onDirection={(d) => (pendingDir.current = d)}
           onPause={togglePause}
           onRestart={restart}
         />
+        <div className="ai-controls">
+          <label htmlFor="aicount">AI Snakes:</label>
+          <input id="aicount" type="range" min="0" max={MAX_AI} value={aiCount} onChange={(e) => setAiCount(Number(e.target.value))} />
+          <span>{aiCount}</span>
+        </div>
       </main>
       {isGameOver && (
         <div className="overlay" role="dialog" aria-modal="true" aria-label="Game Over">

--- a/snake-game/src/components/Board.jsx
+++ b/snake-game/src/components/Board.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
+// snakes: array of { id, body: [{x,y}], direction, kind: 'player'|'ai', aiIndex?: number }
 export default function Board({
-  gridSize,
-  snake,
+  cols,
+  rows,
+  snakes = [],
   food,
   isGameOver,
-  direction,
   onMouseMove,
   onMouseDown,
   onMouseUp,
@@ -13,24 +14,36 @@ export default function Board({
   onContextMenu,
 }) {
   const cells = []
-  const snakeSet = new Set(snake.map((p) => `${p.x},${p.y}`))
-  const headKey = `${snake[0].x},${snake[0].y}`
-  const foodKey = `${food.x},${food.y}`
 
-  for (let y = 0; y < gridSize; y++) {
-    for (let x = 0; x < gridSize; x++) {
+  // Build quick lookup maps for classes per cell
+  const snakeSets = snakes.map((s) => new Set(s.body.map((p) => `${p.x},${p.y}`)))
+  const headKeys = snakes.map((s) => (s.body[0] ? `${s.body[0].x},${s.body[0].y}` : null))
+  const foodKey = food ? `${food.x},${food.y}` : null
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
       const key = `${x},${y}`
       let cls = 'cell'
-      if (snakeSet.has(key)) cls += ' cell-snake'
-      if (key === headKey) {
-        cls += ' cell-snake--head'
-        if (direction?.x === 1) cls += ' head--right'
-        else if (direction?.x === -1) cls += ' head--left'
-        else if (direction?.y === 1) cls += ' head--down'
-        else if (direction?.y === -1) cls += ' head--up'
-      }
-      if (key === foodKey) cls += ' cell-food'
-      cells.push(<div key={key} className={cls} aria-hidden="true" />)
+      let headDirCls = ''
+
+      snakes.forEach((s, idx) => {
+        if (snakeSets[idx].has(key)) {
+          cls += ' cell-snake'
+          if (s.kind === 'player') cls += ' cell-snake--player'
+          else cls += ` cell-snake--ai cell-snake--ai-${s.aiIndex ?? 0}`
+          if (headKeys[idx] === key) {
+            cls += ' cell-snake--head'
+            const d = s.direction
+            if (d?.x === 1) headDirCls = ' head--right'
+            else if (d?.x === -1) headDirCls = ' head--left'
+            else if (d?.y === 1) headDirCls = ' head--down'
+            else if (d?.y === -1) headDirCls = ' head--up'
+          }
+        }
+      })
+
+      if (foodKey && key === foodKey) cls += ' cell-food'
+      cells.push(<div key={key} className={cls + headDirCls} aria-hidden="true" />)
     }
   }
 
@@ -40,9 +53,10 @@ export default function Board({
       role="grid"
       aria-label="Snake board"
       style={{
-        gridTemplateColumns: `repeat(${gridSize}, 1fr)`,
-        gridTemplateRows: `repeat(${gridSize}, 1fr)`,
-        ['--grid-size']: gridSize,
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        gridTemplateRows: `repeat(${rows}, 1fr)`,
+        ['--grid-cols']: cols,
+        ['--grid-rows']: rows,
       }}
       onMouseMove={onMouseMove}
       onMouseDown={onMouseDown}

--- a/snake-game/src/styles.css
+++ b/snake-game/src/styles.css
@@ -1,26 +1,30 @@
 :root {
-  --bg: #f8fafc;
-  --fg: #0f172a;
-  --grid: #e2e8f0;
+  --bg: #0a0f14;
+  --fg: #e5f0ff;
+  --grid: #1a2a36;
   --snake: #10b981;
+  --snake-player: #22c55e;
+  --snake-ai-0: #60a5fa;
+  --snake-ai-1: #f59e0b;
+  --snake-ai-2: #ef4444;
+  --snake-ai-3: #a78bfa;
+  --snake-ai-4: #14b8a6;
   --snake-shade: color-mix(in srgb, var(--snake) 80%, #0000);
   --food: #ef4444;
   --accent: #3b82f6;
-  --board-bg1: #e8f5e9; /* light grass tint */
-  --board-bg2: #f1f8e9; /* lighter tint */
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
-    --bg: #0b1020;
-    --fg: #e5e7eb;
-    --grid: #1f2937;
-    --snake: #22c55e;
-    --snake-shade: color-mix(in srgb, var(--snake) 80%, #0000);
-    --food: #f87171;
-    --accent: #60a5fa;
-    --board-bg1: #0f1a10;
-    --board-bg2: #0c170d;
+    --bg: #f6fbff;
+    --fg: #07131d;
+    --grid: #d7e3ec;
+    --snake-player: #16a34a;
+    --snake-ai-0: #2563eb;
+    --snake-ai-1: #b45309;
+    --snake-ai-2: #dc2626;
+    --snake-ai-3: #7c3aed;
+    --snake-ai-4: #0d9488;
   }
 }
 
@@ -28,48 +32,55 @@
 html, body, #root { height: 100%; }
 body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; background: var(--bg); color: var(--fg); }
 
-.app { min-height: 100%; display: flex; flex-direction: column; align-items: center; gap: 1rem; padding: 1rem; }
-.header { width: 100%; max-width: 720px; display: flex; justify-content: center; align-items: center; }
-.header h1 { margin: 0.5rem 0; font-size: 1.75rem; }
+.app { min-height: 100%; display: flex; flex-direction: column; align-items: stretch; }
+.header { width: 100%; display: flex; justify-content: center; align-items: center; padding: 0.5rem 1rem; }
+.header h1 { margin: 0.25rem 0; font-size: 1.25rem; letter-spacing: 0.02em; opacity: 0.9; }
 
-.main { width: 100%; max-width: 720px; display: grid; gap: 1rem; grid-template-rows: auto 1fr auto; }
+.main { width: 100%; max-width: 960px; margin: 0 auto; display: grid; gap: 0.5rem; grid-template-rows: auto 1fr auto auto; padding: 0 0.75rem 0.75rem; }
 
-.scoreboard { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+/* Fullscreen behavior */
+.fullscreen { min-height: 100vh; }
+.fullscreen-main { height: calc(100vh - 3rem); display: grid; grid-template-rows: auto 1fr auto auto; }
+
+.scoreboard { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; padding: 0.25rem 0; }
 .scores { display: flex; gap: 1rem; }
 .score-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
 
-/* Enhanced board background: subtle grass-like with crisp grid lines via actual grid gap */
+/* Nature-themed animated gradient background for the board container */
 .board {
-  aspect-ratio: 1/1;
   width: 100%;
-  max-width: 640px;
+  height: 100%;
   margin: 0 auto;
   display: grid;
   gap: 1px;
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--board-bg1) 60%, transparent), var(--board-bg2)) padding-box,
-    radial-gradient(circle at 25% 25%, color-mix(in srgb, var(--board-bg2) 85%, transparent) 25%, #0000 26%) 8px 8px / 16px 16px,
-    radial-gradient(circle at 75% 75%, color-mix(in srgb, var(--board-bg1) 65%, transparent) 20%, #0000 21%) 8px 8px / 16px 16px;
-  border-radius: 12px;
+    radial-gradient(120% 120% at 0% 0%, rgba(34,197,94,0.12), transparent 70%),
+    radial-gradient(120% 120% at 100% 100%, rgba(59,130,246,0.10), transparent 70%),
+    linear-gradient(135deg, rgba(16,185,129,0.08), rgba(34,197,94,0.06));
+  background-size: 400% 400%;
+  animation: natureShift 24s ease-in-out infinite;
+  border-radius: 14px;
   overflow: hidden;
   outline: 2px solid var(--grid);
   user-select: none;
   -webkit-user-select: none;
-  touch-action: none; /* avoids unwanted gestures on touchpads */
+  touch-action: none;
 }
+@keyframes natureShift { 0% { background-position: 0% 0%; } 50% { background-position: 100% 100%; } 100% { background-position: 0% 0%; } }
+
 .cell { background: #0000; }
 
 /* Snake visuals: rounded with subtle shading */
-.cell-snake {
-  background: radial-gradient(circle at 30% 30%, var(--snake), var(--snake-shade));
-  border-radius: 8px;
-  box-shadow: inset 0 -2px 0 0 color-mix(in srgb, #000 10%, #0000), inset 0 2px 0 0 color-mix(in srgb, #fff 10%, #0000);
-}
-.cell-snake--head {
-  position: relative;
-  border-radius: 10px;
-}
-/* simple eyes using pseudo-elements via utility classes on head direction */
+.cell-snake { border-radius: 9px; box-shadow: inset 0 -2px 0 0 color-mix(in srgb, #000 12%, #0000), inset 0 2px 0 0 color-mix(in srgb, #fff 10%, #0000); }
+.cell-snake--player { background: radial-gradient(circle at 30% 30%, var(--snake-player), color-mix(in srgb, var(--snake-player) 80%, #0000)); }
+.cell-snake--ai { background: radial-gradient(circle at 30% 30%, var(--snake-ai-0), color-mix(in srgb, var(--snake-ai-0) 80%, #0000)); }
+.cell-snake--ai-0 { background: radial-gradient(circle at 30% 30%, var(--snake-ai-0), color-mix(in srgb, var(--snake-ai-0) 80%, #0000)); }
+.cell-snake--ai-1 { background: radial-gradient(circle at 30% 30%, var(--snake-ai-1), color-mix(in srgb, var(--snake-ai-1) 80%, #0000)); }
+.cell-snake--ai-2 { background: radial-gradient(circle at 30% 30%, var(--snake-ai-2), color-mix(in srgb, var(--snake-ai-2) 80%, #0000)); }
+.cell-snake--ai-3 { background: radial-gradient(circle at 30% 30%, var(--snake-ai-3), color-mix(in srgb, var(--snake-ai-3) 80%, #0000)); }
+.cell-snake--ai-4 { background: radial-gradient(circle at 30% 30%, var(--snake-ai-4), color-mix(in srgb, var(--snake-ai-4) 80%, #0000)); }
+
+.cell-snake--head { position: relative; border-radius: 11px; }
 .cell-snake--head.head--right::before,
 .cell-snake--head.head--right::after,
 .cell-snake--head.head--left::before,
@@ -99,18 +110,21 @@ body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubunt
 
 .board--gameover { filter: grayscale(0.4) brightness(0.9); }
 
-.controls { display: grid; gap: 0.75rem; justify-items: center; }
+.controls { display: grid; gap: 0.5rem; justify-items: center; align-items: center; padding-top: 0.25rem; }
 .dpad { display: grid; grid-template-rows: auto auto auto; gap: 0.25rem; align-items: center; justify-items: center; }
 .hrow { display: grid; grid-template-columns: auto auto; gap: 0.25rem; }
 .actions { display: flex; gap: 0.5rem; }
 
-.btn { background: transparent; color: var(--fg); border: 1px solid var(--grid); padding: 0.5rem 0.75rem; border-radius: 6px; cursor: pointer; }
+.ai-controls { display: flex; align-items: center; gap: 0.5rem; justify-content: center; padding-top: 0.25rem; }
+.ai-controls input[type="range"] { width: 200px; }
+
+.btn { background: transparent; color: var(--fg); border: 1px solid var(--grid); padding: 0.4rem 0.7rem; border-radius: 8px; cursor: pointer; }
 .btn:hover, .btn:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent); }
 .btn:active { transform: translateY(1px); }
 
 .overlay { position: fixed; inset: 0; background: color-mix(in srgb, var(--bg) 60%, transparent); display: grid; place-items: center; }
-.overlay-card { background: var(--bg); color: var(--fg); border: 1px solid var(--grid); border-radius: 12px; padding: 1rem 1.25rem; box-shadow: 0 10px 30px rgba(0,0,0,0.2); text-align: center; }
+.overlay-card { background: var(--bg); color: var(--fg); border: 1px solid var(--grid); border-radius: 12px; padding: 1rem 1.25rem; box-shadow: 0 10px 30px rgba(0,0,0,0.3); text-align: center; }
 
-@media (max-width: 480px) {
-  .header h1 { font-size: 1.4rem; }
+@media (max-width: 600px) {
+  .header h1 { font-size: 1.1rem; }
 }

--- a/snake-game/src/utils/game.js
+++ b/snake-game/src/utils/game.js
@@ -66,6 +66,47 @@ export function spawnFood(gridSize = GRID_DEFAULT, snake) {
   return { x, y }
 }
 
+// New: rectangular-grid aware helpers for AI and fullscreen mode
+export function isReverse(currentDir, nd) {
+  return currentDir && nd && currentDir.x + nd.x === 0 && currentDir.y + nd.y === 0
+}
+
+export function willCollideAt(pos, cols, rows, occupiedSet) {
+  // bounds
+  if (pos.x < 0 || pos.y < 0 || pos.x >= cols || pos.y >= rows) return true
+  // body occupancy
+  if (occupiedSet && occupiedSet.has(`${pos.x},${pos.y}`)) return true
+  return false
+}
+
+export function spawnFoodWithOccupied(cols, rows, occupiedSet) {
+  const total = cols * rows
+  if (occupiedSet.size >= total) return { x: 0, y: 0 }
+  let x, y
+  let safety = 0
+  do {
+    x = Math.floor(Math.random() * cols)
+    y = Math.floor(Math.random() * rows)
+    safety++
+  } while (occupiedSet.has(`${x},${y}`) && safety < total + 5)
+  return { x, y }
+}
+
+export function chooseNearestFood(head, foods) {
+  if (!foods || foods.length === 0) return null
+  let best = foods[0]
+  let bestDist = Math.abs(best.x - head.x) + Math.abs(best.y - head.y)
+  for (let i = 1; i < foods.length; i++) {
+    const f = foods[i]
+    const d = Math.abs(f.x - head.x) + Math.abs(f.y - head.y)
+    if (d < bestDist) {
+      best = f
+      bestDist = d
+    }
+  }
+  return best
+}
+
 // Decide a grid direction that steers the snake head toward a target cell without reversing.
 export function nextDirectionTowardTarget(head, currentDir, target) {
   if (!target) return currentDir
@@ -85,11 +126,82 @@ export function nextDirectionTowardTarget(head, currentDir, target) {
   const secondary = tryXFirst ? dirFor(Math.sign(dy), 'y') : dirFor(Math.sign(dx), 'x')
 
   // Helper to check reverse
-  function isReverse(nd) {
+  function isRev(nd) {
     return currentDir && currentDir.x + nd.x === 0 && currentDir.y + nd.y === 0
   }
 
-  if (primary && !isReverse(primary)) return primary
-  if (secondary && !isReverse(secondary)) return secondary
+  if (primary && !isRev(primary)) return primary
+  if (secondary && !isRev(secondary)) return secondary
   return currentDir
+}
+
+// Greedy AI step: prefer moving toward nearest food, avoid immediate collisions (walls/occupied next cells),
+// respect no-reverse rule; try alternatives when blocked.
+export function nextSafeDirectionTowardTarget(head, currentDir, target, {
+  cols,
+  rows,
+  occupiedSet,
+  ownTail,
+  willGrow,
+} = {}) {
+  // Fallback to existing heuristic first to get a preference ordering
+  const pref1 = nextDirectionTowardTarget(head, currentDir, target)
+
+  const allDirs = [DIRECTIONS.UP, DIRECTIONS.DOWN, DIRECTIONS.LEFT, DIRECTIONS.RIGHT]
+  const noReverse = (d) => !isReverse(currentDir, d)
+
+  // Create an ordered list to try: primary, secondary from heuristic, then the remaining
+  const dx = target ? target.x - head.x : 0
+  const dy = target ? target.y - head.y : 0
+  const tryXFirst = Math.abs(dx) >= Math.abs(dy)
+  const dirFor = (sign, axis) => (axis === 'x' ? (sign > 0 ? DIRECTIONS.RIGHT : DIRECTIONS.LEFT) : (sign > 0 ? DIRECTIONS.DOWN : DIRECTIONS.UP))
+  const primary = pref1
+  const secondary = tryXFirst ? dirFor(Math.sign(dy), 'y') : dirFor(Math.sign(dx), 'x')
+  const candidates = [primary, secondary, ...allDirs.filter((d) => d !== primary && d !== secondary)]
+
+  for (const cand of candidates) {
+    if (!cand || !noReverse(cand)) continue
+    const next = { x: head.x + cand.x, y: head.y + cand.y }
+    // Allow stepping onto own tail if not growing (tail will vacate)
+    const occ = new Set(occupiedSet || [])
+    if (ownTail && !willGrow) occ.delete(`${ownTail.x},${ownTail.y}`)
+    if (!willCollideAt(next, cols, rows, occ)) return cand
+  }
+  // If everything seems blocked, try to keep going if it's not an immediate collision
+  if (currentDir) {
+    const next = { x: head.x + currentDir.x, y: head.y + currentDir.y }
+    const occ = new Set(occupiedSet || [])
+    if (ownTail && !willGrow) occ.delete(`${ownTail.x},${ownTail.y}`)
+    if (!willCollideAt(next, cols, rows, occ)) return currentDir
+  }
+  // As a last resort, pick any non-reverse direction (might collide; caller will handle death)
+  for (const d of allDirs) if (noReverse(d)) return d
+  return currentDir || DIRECTIONS.RIGHT
+}
+
+export function rectCheckSelfOrWallCollision(snake, cols, rows) {
+  const [head, ...body] = snake
+  if (head.x < 0 || head.y < 0 || head.x >= cols || head.y >= rows) return true
+  return body.some((p) => p.x === head.x && p.y === head.y)
+}
+
+export function spawnRandomSnake(cols, rows, occupiedSet) {
+  // Attempt to place a 2-length snake in a random safe spot with a valid initial direction
+  const attempts = Math.max(200, cols * rows)
+  for (let i = 0; i < attempts; i++) {
+    const x = Math.floor(Math.random() * cols)
+    const y = Math.floor(Math.random() * rows)
+    const dirs = [DIRECTIONS.UP, DIRECTIONS.DOWN, DIRECTIONS.LEFT, DIRECTIONS.RIGHT]
+    for (const d of dirs) {
+      const head = { x, y }
+      const tail = { x: x - d.x, y: y - d.y }
+      const okHead = !willCollideAt(head, cols, rows, occupiedSet)
+      const okTail = !willCollideAt(tail, cols, rows, occupiedSet)
+      if (okHead && okTail) {
+        return { body: [head, tail], direction: d }
+      }
+    }
+  }
+  // Fallback: place at (0,0) to avoid crash
+  return { body: [{ x: 1, y: 1 }, { x: 0, y: 1 }], direction: DIRECTIONS.RIGHT }
 }

--- a/snake-game/tests/ai.test.js
+++ b/snake-game/tests/ai.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { DIRECTIONS, nextSafeDirectionTowardTarget, chooseNearestFood, isReverse } from '../src/utils/game.js'
+
+describe('AI utilities', () => {
+  it('chooseNearestFood picks the closest by manhattan distance', () => {
+    const head = { x: 5, y: 5 }
+    const foods = [{ x: 9, y: 5 }, { x: 4, y: 3 }, { x: 6, y: 6 }]
+    const f = chooseNearestFood(head, foods)
+    expect(f).toEqual({ x: 6, y: 6 })
+  })
+
+  it('isReverse blocks 180-degree turns', () => {
+    expect(isReverse(DIRECTIONS.RIGHT, DIRECTIONS.LEFT)).toBe(true)
+    expect(isReverse(DIRECTIONS.UP, DIRECTIONS.DOWN)).toBe(true)
+    expect(isReverse(DIRECTIONS.LEFT, DIRECTIONS.UP)).toBe(false)
+  })
+
+  it('nextSafeDirectionTowardTarget prefers safe primary direction', () => {
+    const head = { x: 2, y: 2 }
+    const target = { x: 5, y: 2 }
+    const current = DIRECTIONS.UP
+    const cols = 10, rows = 10
+    const occupiedSet = new Set(['3,2']) // block the primary step to the right of head
+    const nd = nextSafeDirectionTowardTarget(head, current, target, { cols, rows, occupiedSet, ownTail: { x: 2, y: 3 }, willGrow: false })
+    // Right would be primary but is blocked, so should choose a safe alternative that is not reverse
+    expect(nd).not.toEqual(DIRECTIONS.RIGHT)
+    expect(nd).not.toEqual(DIRECTIONS.DOWN) // reverse of current
+  })
+
+  it('nextSafeDirectionTowardTarget allows stepping into own tail when not growing', () => {
+    const head = { x: 2, y: 2 }
+    const target = { x: 2, y: 5 }
+    const current = DIRECTIONS.DOWN
+    const cols = 6, rows = 6
+    const occupiedSet = new Set(['2,3']) // own tail here
+    const nd = nextSafeDirectionTowardTarget(head, current, target, { cols, rows, occupiedSet, ownTail: { x: 2, y: 3 }, willGrow: false })
+    expect(nd).toEqual(DIRECTIONS.DOWN)
+  })
+})


### PR DESCRIPTION
This PR implements a fullscreen, responsive Snake game board, adds optional AI opponents, and applies nature-themed visual polish — all within the Vite + React subdir.

Highlights
- Fullscreen responsive board
  - Computes rows/cols from viewport; ~20px logical tile size
  - Handles window resize
  - Preserves mouse and keyboard controls

- Multiple AI snakes (0..5, default 3)
  - Slider UI to change count mid-session
  - Greedy nearest-food pursuit with safe-step heuristic (no-reverse + next-cell occupancy)
  - AI dies on collisions (wall/self/player/other AI) and respawns after a short delay at a safe random spot
  - Shared food: any snake that reaches it grows; player score increments only for player eating

- Visual polish
  - Subtle animated, nature-themed gradient background (CSS-only, no heavy images)
  - Rounded segments with shading; heads have eyes indicating direction
  - Distinct colors for AI snakes

- Mouse controls kept and toggleable
  - Cursor steering; LMB Boost; RMB Brake; context menu suppressed

- Docs + tests
  - README updated with controls and AI rules
  - Unit tests for AI utilities (target choose, no-reverse, safe-step preference)

Implementation notes
- Board component now supports rectangular grids and multiple snakes; retains head direction classes
- Added utils for AI: occupancy-aware food spawn, safe-direction computation, and random AI spawn
- Kept changes isolated to App, Board, styles, utils, and README/tests only

Manual checks
- Run in subdir: `cd snake-game && npm i && npm run dev`
- Tests: `npm test` (Vitest)
- Build: `npm run build`

Screenshots/GIFs
- [Add gameplay GIF here]
- [Add fullscreen + AI color showcase here]

Closes: N/A