### PR TITLE
fix(shooting-game): unstick Play start and improve engine lifecycle

### DIFF
--- a/shooting-game/README.md
+++ b/shooting-game/README.md
@@ -30,5 +30,8 @@ Controls:
 Tests:
 - npm test
 
+Troubleshooting:
+- If clicking Play shows a blank canvas: ensure the canvas element is present in index.html and that the app has focus. As of this fix, the engine resets its clock on focus and mount to avoid a stuck loop when the tab was previously hidden. Also try clicking the page once to allow audio context to resume.
+
 Notes:
 - Keep assets lightweight (no large binaries). All sfx generated via WebAudio.

--- a/shooting-game/src/App.jsx
+++ b/shooting-game/src/App.jsx
@@ -55,7 +55,8 @@ export default function App(){
     const g = createGame(settings)
     setGame(g)
     setUi({screen:'playing'})
-    setTimeout(()=> g.mount(canvasRef.current), 0)
+    // Mount immediately; allow a microtask to ensure canvasRef is set but don't defer a full frame
+    Promise.resolve().then(()=> g.mount(canvasRef.current))
   }
 
   return (

--- a/shooting-game/src/game/engine.js
+++ b/shooting-game/src/game/engine.js
@@ -19,6 +19,8 @@ export function createGame(initialSettings){
     camera: vec(0,0),
     settings,
     stats: {remaining:0},
+    canvas: null,
+    ctx: null,
   }
   const player = createPlayer(700, 700)
   state.player = player
@@ -184,9 +186,13 @@ export function createGame(initialSettings){
     if ((code==='Enter' || code==='NumpadEnter') && down && state.player.dead) return 'restart'
   }
 
+  const raf = (typeof window !== 'undefined' && window.requestAnimationFrame)
+    ? (cb)=>window.requestAnimationFrame(cb)
+    : (cb)=> setTimeout(()=>cb((typeof performance!=='undefined' && performance.now)?performance.now():Date.now()), 16)
+
   function fixedUpdateLoop(time){
     if (!state.running) return
-    if (document.hidden){ state.lastTime = time; requestAnimationFrame(fixedUpdateLoop); return }
+    if (typeof document !== 'undefined' && document.hidden){ state.lastTime = time; raf(fixedUpdateLoop); return }
     if (state.lastTime===0) state.lastTime = time
     let frame = (time - state.lastTime)/1000
     if (frame>0.25) frame = 0.25
@@ -199,30 +205,40 @@ export function createGame(initialSettings){
     }
     const canvas = state.canvas
     const ctx2d = state.ctx
+    if (!canvas || !ctx2d){ raf(fixedUpdateLoop); return }
     const {width, height} = canvas
     render(ctx2d, width, height)
-    requestAnimationFrame(fixedUpdateLoop)
+    raf(fixedUpdateLoop)
   }
 
   function mount(canvas){
+    if (!canvas) return
     state.canvas = canvas
     const ctx2d = canvas.getContext('2d')
     state.ctx = ctx2d
     resize()
     state.running = true
-    requestAnimationFrame(fixedUpdateLoop)
+    state.lastTime = 0 // reset timeline when (re)mounting
+    raf(fixedUpdateLoop)
   }
 
   function resize(){
-    const dpr = Math.min(window.devicePixelRatio||1, 2)
-    const rect = state.canvas.getBoundingClientRect()
+    if (!state.canvas || !state.ctx) return
+    const dpr = (typeof window !== 'undefined') ? Math.min(window.devicePixelRatio||1, 2) : 1
+    let rect = {width:0, height:0}
+    if (typeof state.canvas.getBoundingClientRect === 'function'){
+      rect = state.canvas.getBoundingClientRect()
+    }
+    if (!rect.width || !rect.height){
+      rect = (typeof window !== 'undefined') ? {width: window.innerWidth, height: window.innerHeight} : {width: 800, height: 600}
+    }
     state.canvas.width = Math.floor(rect.width * dpr)
     state.canvas.height = Math.floor(rect.height * dpr)
     state.ctx.setTransform(dpr,0,0,dpr,0,0)
   }
 
   function blur(){ state.paused = true }
-  function focus(){ state.paused = false }
+  function focus(){ state.paused = false; state.lastTime = 0 }
 
   return { state, mount, resize, blur, focus, onMouseMove, onMouseDown, onMouseUp, onKey }
 }

--- a/shooting-game/tests/engine.test.js
+++ b/shooting-game/tests/engine.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createGame } from '../src/game/engine.js'
+
+function makeCanvas(){
+  const ctx = {
+    setTransform: vi.fn(),
+    clearRect: vi.fn(),
+    fillStyle: '#000',
+    fillRect: vi.fn(),
+    strokeStyle: '#fff',
+    lineWidth: 1,
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    fillText: vi.fn(),
+  }
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({width: 800, height: 600}),
+  }
+  return {canvas, ctx}
+}
+
+describe('engine mount/start', ()=>{
+  beforeEach(()=>{ vi.useFakeTimers() })
+  afterEach(()=>{ vi.useRealTimers() })
+
+  it('mounts, starts loop, and toggles pause on blur/focus', ()=>{
+    const {canvas} = makeCanvas()
+    const g = createGame({bots:0, audio:false})
+    expect(g.state.running).toBe(false)
+    g.mount(canvas)
+    expect(g.state.canvas).toBe(canvas)
+    expect(g.state.ctx).toBeTruthy()
+    expect(g.state.running).toBe(true)
+    // advance a couple of frames via RAF fallback
+    vi.advanceTimersByTime(40)
+    // blur/focus toggles paused
+    g.blur(); expect(g.state.paused).toBe(true)
+    g.focus(); expect(g.state.paused).toBe(false)
+  })
+})


### PR DESCRIPTION
Root cause:
- Game loop could start in a "stuck" state if Play was pressed while the tab was hidden or if canvas/context were not yet available. lastTime stayed stale and RAF short-circuited on document.hidden, preventing the first frame. Also, mount used a strict window.requestAnimationFrame and relied on a setTimeout deferral from App which could race with canvas ref.

Fix:
- Engine now uses a raf wrapper that falls back to setTimeout in non-window/test envs. On mount/focus we reset lastTime=0 and always schedule the loop, and guard rendering until canvas/ctx are ready. Resize now tolerates missing getBoundingClientRect by falling back to window size.
- In App, start() mounts the engine in a microtask (Promise.resolve) so canvasRef is present without waiting a full frame.
- Focus/blur now properly pause and resume without permanently pausing; focus resets lastTime to avoid giant delta or a paused loop.

Acceptance verified manually:
- Clicking Play transitions to gameplay: canvas renders, loop advances, player input works; no console errors when loading or after Play. Tabbing away pauses, returning resumes gameplay.

Tests:
- Added tests/tests/engine.test.js covering engine mount/loop start and blur/focus toggling using Vitest and RAF fallback.

Docs:
- README troubleshooting notes about blank canvas and focus/audio context resume.

No other features were changed.