### PR TITLE
feat(calculator): add React + Vite calculator app with evaluator tests

### DIFF
--- a/apps/calculator/README.md
+++ b/apps/calculator/README.md
@@ -1,0 +1,36 @@
+# React Calculator
+
+A lightweight calculator built with React + Vite.
+
+Features:
+- +, −, ×, ÷
+- Parentheses and operator precedence
+- Unary minus, decimals
+- Keyboard support (0–9 . + - * / ( )  Enter  =  Backspace  Esc)
+- Error messages (divide by zero, mismatched parentheses, invalid input)
+
+## Scripts
+
+From repo root (workspaces configured):
+- npm run dev — start dev server for the calculator
+- npm run build — build the app
+- npm run preview — preview the build
+- npm test — run unit tests (Vitest)
+
+Or inside apps/calculator:
+- npm run dev | build | preview | test
+
+## Run locally
+
+- npm install (on first run; CI prepares lockfile automatically)
+- npm run dev
+- Open http://localhost:5173
+
+## Build
+
+- npm run build
+- Static files in apps/calculator/dist
+
+## Tests
+
+- npm test

--- a/apps/calculator/index.html
+++ b/apps/calculator/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Calculator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/apps/calculator/package.json
+++ b/apps/calculator/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-calculator",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.0",
+    "vite": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/apps/calculator/src/App.jsx
+++ b/apps/calculator/src/App.jsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useState } from 'react'
+import { evaluate } from './lib/evaluate.js'
+
+const buttons = [
+  { label: 'C', action: 'clear', className: 'btn-danger' },
+  { label: '(', action: 'input', value: '(', className: 'btn-operator' },
+  { label: ')', action: 'input', value: ')', className: 'btn-operator' },
+  { label: '⌫', action: 'backspace' },
+
+  { label: '7', action: 'input', value: '7' },
+  { label: '8', action: 'input', value: '8' },
+  { label: '9', action: 'input', value: '9' },
+  { label: '÷', action: 'input', value: '/' , className: 'btn-operator'},
+
+  { label: '4', action: 'input', value: '4' },
+  { label: '5', action: 'input', value: '5' },
+  { label: '6', action: 'input', value: '6' },
+  { label: '×', action: 'input', value: '*', className: 'btn-operator' },
+
+  { label: '1', action: 'input', value: '1' },
+  { label: '2', action: 'input', value: '2' },
+  { label: '3', action: 'input', value: '3' },
+  { label: '−', action: 'input', value: '-', className: 'btn-operator' },
+
+  { label: '0', action: 'input', value: '0' },
+  { label: '.', action: 'input', value: '.' },
+  { label: '=', action: 'equals', className: 'btn-accent btn-wide' },
+  { label: '+', action: 'input', value: '+', className: 'btn-operator' },
+]
+
+export default function App() {
+  const [expr, setExpr] = useState('')
+  const [result, setResult] = useState('0')
+  const [error, setError] = useState('')
+
+  const append = (val) => {
+    setExpr((e) => e + val)
+    setError('')
+  }
+
+  const clear = () => {
+    setExpr('')
+    setResult('0')
+    setError('')
+  }
+
+  const backspace = () => {
+    setExpr((e) => e.slice(0, -1))
+    setError('')
+  }
+
+  const equals = () => {
+    try {
+      const val = evaluate(expr === '' ? '0' : expr)
+      setResult(String(val))
+      setError('')
+    } catch (err) {
+      setError(err.message || 'Error')
+    }
+  }
+
+  useEffect(() => {
+    const onKey = (e) => {
+      const key = e.key
+      if ((key >= '0' && key <= '9') || key === '.' || key === '+' || key === '-' || key === '*' || key === '/' || key === '(' || key === ')') {
+        append(key)
+        e.preventDefault()
+      } else if (key === 'Enter' || key === '=') {
+        equals(); e.preventDefault()
+      } else if (key === 'Backspace') {
+        backspace(); e.preventDefault()
+      } else if (key === 'Escape') {
+        clear(); e.preventDefault()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  return (
+    <div className="container">
+      <div className="calculator" role="application" aria-label="Calculator">
+        <div className="display">
+          <div className="expr" aria-live="polite">{expr || '\u00A0'}</div>
+          {error ? (
+            <div className="error" aria-live="assertive">{error}</div>
+          ) : (
+            <div className="result" aria-live="polite">{result}</div>
+          )}
+          <div className="keyboard-hint">Keys: 0–9 . + - * / ( )  Enter =  Backspace  Esc</div>
+        </div>
+        <div className="grid">
+          {buttons.map((b) => (
+            <button
+              key={b.label}
+              className={[b.className].filter(Boolean).join(' ')}
+              onClick={() => {
+                if (b.action === 'input') append(b.value)
+                else if (b.action === 'equals') equals()
+                else if (b.action === 'clear') clear()
+                else if (b.action === 'backspace') backspace()
+              }}
+              aria-label={b.action === 'input' ? `Insert ${b.value}` : b.label}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+        <div className="footer">
+          <span>React + Vite</span>
+          <a className="link" href="https://github.com/Abhishek-0005/Abhishek-0005/tree/feat/react-calculator/apps/calculator" target="_blank" rel="noreferrer">Source</a>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/calculator/src/lib/evaluate.js
+++ b/apps/calculator/src/lib/evaluate.js
@@ -1,0 +1,141 @@
+// Expression evaluator supporting +, -, *, /, parentheses, and unary minus
+// Implements shunting-yard to convert to RPN, then evaluates.
+
+const isDigit = (ch) => /[0-9]/.test(ch)
+
+function tokenize(input) {
+  const tokens = []
+  let i = 0
+  let prevType = 'start' // 'start' | 'number' | 'op' | 'lparen' | 'rparen'
+
+  while (i < input.length) {
+    const ch = input[i]
+
+    if (ch === ' ' || ch === '\t' || ch === '\n') { i++; continue }
+
+    if (isDigit(ch) || ch === '.') {
+      let numStr = ''
+      let dotCount = 0
+      while (i < input.length && (isDigit(input[i]) || input[i] === '.')) {
+        if (input[i] === '.') {
+          dotCount++
+          if (dotCount > 1) throw new Error('Invalid number')
+        }
+        numStr += input[i]
+        i++
+      }
+      if (numStr === '.' ) throw new Error('Invalid number')
+      tokens.push({ type: 'number', value: parseFloat(numStr) })
+      prevType = 'number'
+      continue
+    }
+
+    if (ch === '+' || ch === '-' ) {
+      // Determine unary or binary
+      const isUnary = (prevType === 'start' || prevType === 'op' || prevType === 'lparen')
+      tokens.push({ type: 'op', value: isUnary && ch === '-' ? 'u-' : ch })
+      prevType = 'op'
+      i++
+      continue
+    }
+
+    if (ch === '*' || ch === '/') {
+      tokens.push({ type: 'op', value: ch })
+      prevType = 'op'
+      i++
+      continue
+    }
+
+    if (ch === '(') { tokens.push({ type: 'lparen', value: ch }); prevType = 'lparen'; i++; continue }
+    if (ch === ')') { tokens.push({ type: 'rparen', value: ch }); prevType = 'rparen'; i++; continue }
+
+    throw new Error('Invalid input')
+  }
+
+  return tokens
+}
+
+function toRPN(tokens) {
+  const out = []
+  const stack = []
+
+  const prec = { '+': 1, '-': 1, '*': 2, '/': 2, 'u-': 3 }
+  const rightAssoc = { 'u-': true }
+  const arity = { '+': 2, '-': 2, '*': 2, '/': 2, 'u-': 1 }
+
+  for (const t of tokens) {
+    if (t.type === 'number') {
+      out.push(t)
+    } else if (t.type === 'op') {
+      while (stack.length) {
+        const top = stack[stack.length - 1]
+        if (top.type !== 'op') break
+        const shouldPop = (
+          (!rightAssoc[t.value] && prec[t.value] <= prec[top.value]) ||
+          (rightAssoc[t.value] && prec[t.value] < prec[top.value])
+        )
+        if (shouldPop) out.push(stack.pop())
+        else break
+      }
+      stack.push(t)
+    } else if (t.type === 'lparen') {
+      stack.push(t)
+    } else if (t.type === 'rparen') {
+      let found = false
+      while (stack.length) {
+        const s = stack.pop()
+        if (s.type === 'lparen') { found = true; break }
+        out.push(s)
+      }
+      if (!found) throw new Error('Mismatched parentheses')
+    }
+  }
+
+  while (stack.length) {
+    const s = stack.pop()
+    if (s.type === 'lparen' || s.type === 'rparen') throw new Error('Mismatched parentheses')
+    out.push(s)
+  }
+
+  return { rpn: out, arity }
+}
+
+export function evaluate(expr) {
+  const tokens = tokenize(expr)
+  const { rpn, arity } = toRPN(tokens)
+
+  const stack = []
+  for (const t of rpn) {
+    if (t.type === 'number') {
+      stack.push(t.value)
+    } else if (t.type === 'op') {
+      const n = arity[t.value]
+      if (n === 1) {
+        if (stack.length < 1) throw new Error('Invalid expression')
+        const a = stack.pop()
+        if (t.value === 'u-') stack.push(-a)
+        else throw new Error('Invalid operator')
+      } else if (n === 2) {
+        if (stack.length < 2) throw new Error('Invalid expression')
+        const b = stack.pop()
+        const a = stack.pop()
+        let res
+        switch (t.value) {
+          case '+': res = a + b; break
+          case '-': res = a - b; break
+          case '*': res = a * b; break
+          case '/':
+            if (b === 0) throw new Error('Division by zero')
+            res = a / b; break
+          default: throw new Error('Invalid operator')
+        }
+        stack.push(res)
+      } else {
+        throw new Error('Invalid operator')
+      }
+    }
+  }
+
+  if (stack.length !== 1) throw new Error('Invalid expression')
+  return stack[0]
+}

--- a/apps/calculator/src/main.jsx
+++ b/apps/calculator/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/apps/calculator/src/styles.css
+++ b/apps/calculator/src/styles.css
@@ -1,0 +1,115 @@
+:root {
+  --bg: #0f172a;
+  --panel: #111827;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #22c55e;
+  --danger: #ef4444;
+  --btn: #1f2937;
+  --btn-alt: #374151;
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  background: radial-gradient(1200px 800px at 70% -10%, #1f2937, #0b1020 70%, #070b16 100%);
+  color: var(--text);
+}
+
+.container {
+  min-height: 100%;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.calculator {
+  width: 360px;
+  background: linear-gradient(180deg, #0b1224, #0a1020);
+  border: 1px solid #1f2a44;
+  border-radius: 16px;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.05);
+  overflow: hidden;
+}
+
+.display {
+  padding: 1rem 1.25rem 0.5rem;
+  min-height: 88px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(0,0,0,0.12));
+  border-bottom: 1px solid #1f2a44;
+}
+
+.expr {
+  min-height: 24px;
+  color: var(--muted);
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.result {
+  font-size: 1.9rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.error {
+  color: var(--danger);
+  font-size: 0.9rem;
+}
+
+.keyboard-hint {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding: 10px;
+}
+
+button {
+  background: linear-gradient(180deg, #121a2d, #0e172a);
+  border: 1px solid #1f2a44;
+  color: var(--text);
+  padding: 14px 10px;
+  font-size: 1.1rem;
+  border-radius: 10px;
+  cursor: pointer;
+  outline: none;
+  transition: transform 0.05s ease, box-shadow 0.15s ease, background 0.2s ease;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.25), inset 0 1px 0 rgba(255,255,255,0.05);
+}
+
+button:hover {
+  box-shadow: 0 4px 14px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.06);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.btn-operator { background: linear-gradient(180deg, #1b2a46, #15243f); }
+.btn-accent { background: linear-gradient(180deg, #1b3a2a, #153f2a); border-color: #1b4f34; }
+.btn-danger { background: linear-gradient(180deg, #3a1b1b, #3f1515); border-color: #4f1b1b; }
+.btn-wide { grid-column: span 2; }
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.9rem 1rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.link { color: #8ab4f8; text-decoration: none; }
+.link:hover { text-decoration: underline; }

--- a/apps/calculator/tests/evaluate.test.js
+++ b/apps/calculator/tests/evaluate.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { evaluate } from '../src/lib/evaluate.js'
+
+describe('evaluate', () => {
+  it('adds, subtracts, multiplies, divides', () => {
+    expect(evaluate('1+2')).toBe(3)
+    expect(evaluate('7-5')).toBe(2)
+    expect(evaluate('3*4')).toBe(12)
+    expect(evaluate('8/2')).toBe(4)
+  })
+
+  it('respects precedence', () => {
+    expect(evaluate('2+3*4')).toBe(14)
+    expect(evaluate('2*3+4')).toBe(10)
+  })
+
+  it('handles parentheses', () => {
+    expect(evaluate('2*(3+4)')).toBe(14)
+    expect(evaluate('(1+2)*(3+4)')).toBe(21)
+  })
+
+  it('handles unary minus', () => {
+    expect(evaluate('-5+2')).toBe(-3)
+    expect(evaluate('3+-2')).toBe(1)
+    expect(evaluate('3*-2')).toBe(-6)
+  })
+
+  it('handles decimals', () => {
+    expect(evaluate('7/2')).toBeCloseTo(3.5)
+    expect(evaluate('0.5+0.25')).toBeCloseTo(0.75)
+  })
+
+  it('complex example', () => {
+    expect(evaluate('3+4*2/(1-5)')).toBe(1)
+  })
+
+  it('errors: division by zero', () => {
+    expect(() => evaluate('1/0')).toThrow('Division by zero')
+  })
+
+  it('errors: invalid number', () => {
+    expect(() => evaluate('1..2')).toThrow()
+  })
+
+  it('errors: mismatched parentheses', () => {
+    expect(() => evaluate('(1+2')).toThrow('Mismatched parentheses')
+  })
+})

--- a/apps/calculator/vite.config.js
+++ b/apps/calculator/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'node'
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "abhishek-0005-monorepo",
+  "private": true,
+  "version": "1.0.0",
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "dev": "npm run -w apps/calculator dev",
+    "build": "npm run -w apps/calculator build",
+    "preview": "npm run -w apps/calculator preview",
+    "test": "npm run -w apps/calculator test --"
+  }
+}


### PR DESCRIPTION
This PR adds a React + Vite calculator under apps/calculator with an expression evaluator (shunting-yard) and unit tests (Vitest).

Highlights:
- Calculator UI with keyboard support and error handling
- Evaluator supporting +, −, ×, ÷, parentheses, unary −, decimals
- Vitest unit tests
- Root workspace package.json for convenient scripts
- CI prepared on main; ci-prepare succeeded on this branch

How to run locally:
- npm install
- npm run dev
- Visit http://localhost:5173

Tests:
- npm test

CI-prepare run URL: https://github.com/Abhishek-0005/Abhishek-0005/actions/runs/29307503090

Marking ready for review.